### PR TITLE
Use 'use x' instead of 'use namespace x'

### DIFF
--- a/aves.tests/WrappedIterator.osp
+++ b/aves.tests/WrappedIterator.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace aves.tests;
 

--- a/aves.tests/aves.tests.osp
+++ b/aves.tests/aves.tests.osp
@@ -1,8 +1,8 @@
 use "WrappedIterator.osp";
 
-use namespace aves;
-use namespace aves.reflection; // for Module
-use namespace testing.unit;
+use aves;
+use aves.reflection; // for Module
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/ArrayTests.osp
+++ b/aves.tests/aves/ArrayTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/BooleanTests.osp
+++ b/aves.tests/aves/BooleanTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/BufferTests.osp
+++ b/aves.tests/aves/BufferTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/BufferViewTests.osp
+++ b/aves.tests/aves/BufferViewTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/CharTests.osp
+++ b/aves.tests/aves/CharTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/HashTests.osp
+++ b/aves.tests/aves/HashTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/IterableTests.osp
+++ b/aves.tests/aves/IterableTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/IteratorTests.osp
+++ b/aves.tests/aves/IteratorTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/ListTests.osp
+++ b/aves.tests/aves/ListTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/ObjectTests.osp
+++ b/aves.tests/aves/ObjectTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/QueueTests.osp
+++ b/aves.tests/aves/QueueTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/SetTests.osp
+++ b/aves.tests/aves/SetTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/StackTests.osp
+++ b/aves.tests/aves/StackTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/StringTests.osp
+++ b/aves.tests/aves/StringTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/aves/TimeSpanTests.osp
+++ b/aves.tests/aves/TimeSpanTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/equalityComparers.osp
+++ b/aves.tests/equalityComparers.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace aves.tests;
 

--- a/aves.tests/math/MathTests.osp
+++ b/aves.tests/math/MathTests.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace math.tests;
 

--- a/aves/osp/io/BinaryReader.osp
+++ b/aves/osp/io/BinaryReader.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/BinaryWriter.osp
+++ b/aves/osp/io/BinaryWriter.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/Directory.osp
+++ b/aves/osp/io/Directory.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/EndOfFileError.osp
+++ b/aves/osp/io/EndOfFileError.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/File.osp
+++ b/aves/osp/io/File.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/FileNotFoundError.osp
+++ b/aves/osp/io/FileNotFoundError.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/FileStream.osp
+++ b/aves/osp/io/FileStream.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/IOError.osp
+++ b/aves/osp/io/IOError.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/Path.osp
+++ b/aves/osp/io/Path.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/Stream.osp
+++ b/aves/osp/io/Stream.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/TextReader.osp
+++ b/aves/osp/io/TextReader.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/TextWriter.osp
+++ b/aves/osp/io/TextWriter.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/io/errorHelpers.osp
+++ b/aves/osp/io/errorHelpers.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io.errorHelpers;
 

--- a/aves/osp/io/fileenums.osp
+++ b/aves/osp/io/fileenums.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace io;
 

--- a/aves/osp/math/Random.osp
+++ b/aves/osp/math/Random.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace math;
 

--- a/aves/osp/math/math.osp
+++ b/aves/osp/math/math.osp
@@ -1,6 +1,6 @@
 use "Random.osp";
 
-use namespace aves;
+use aves;
 
 namespace math
 {


### PR DESCRIPTION
osprey-lang/ospc#1 and osprey-lang/osprey#1 change the 'use namespace x' syntax to just 'use x', which naturally breaks a lot of source files. Update source files.