### PR TITLE
Normalize integral type use, especially size_t

### DIFF
--- a/Ovum/main.cpp
+++ b/Ovum/main.cpp
@@ -34,8 +34,7 @@ int wmain(int argc, wchar_t *argv[])
 	if (argc == 1)
 		PrintUsageAndExit();
 
-	OvumArgs args;
-	memset(&args, 0, sizeof(OvumArgs)); // initialize to zero
+	OvumArgs args = { 0 };
 	ParseCommandLine(argc - 1, argv + 1, args);
 
 	VMStartParams vm;

--- a/aves.tests/aves/HashTests.osp
+++ b/aves.tests/aves/HashTests.osp
@@ -39,8 +39,9 @@ public class HashTests is TestFixture
 	public test_Constructor1WithTooMuchCapacity()
 	{
 		// If Hash.maxCapacity == Int.max, then we can't do anything
-		if Hash.maxCapacity == Int.max:
+		if Hash.maxCapacity == Int.max {
 			return;
+		}
 
 		var capacity = Hash.maxCapacity + 1;
 		Assert.throws(typeof(ArgumentRangeError), @=> new Hash(capacity));
@@ -247,7 +248,40 @@ public class HashTests is TestFixture
 		Assert.throws(typeof(ArgumentNullError), @=> h.get(null, 0));
 	}
 
-	// Concat tests
+	// tryGet tests
+
+	public test_TryGetExisting()
+	{
+		var h = new Hash(1);
+		h[42] = "value";
+
+		var value;
+		Assert.isTrue(h.tryGet(42, ref value));
+		Assert.areEqual(value, "value");
+	}
+
+	public test_TryGetMissing()
+	{
+		var h = new Hash(1);
+		h[42] = "value";
+
+		var value;
+		Assert.isFalse(h.tryGet(47, ref value));
+		Assert.isNull(value);
+	}
+
+	public test_TryGetInvalid()
+	{
+		var h = new Hash(1);
+		h[42] = "value";
+
+		Assert.throws(typeof(ArgumentNullError), @{
+			var value;
+			h.tryGet(null, ref value);
+		});
+	}
+
+	// concat tests
 
 	public test_ConcatWithUniqueKeys()
 	{

--- a/aves/cpp/aves/array.cpp
+++ b/aves/cpp/aves/array.cpp
@@ -7,7 +7,7 @@ using namespace aves;
 namespace aves
 {
 
-int Array::GetIndex(ThreadHandle thread, Value *arg, int64_t &result)
+int Array::GetIndex(ThreadHandle thread, Value *arg, size_t &result)
 {
 	Aves *aves = Aves::Get(thread);
 
@@ -15,13 +15,13 @@ int Array::GetIndex(ThreadHandle thread, Value *arg, int64_t &result)
 	if (r != OVUM_SUCCESS)
 		return r;
 	int64_t index = arg->v.integer;
-	if (index < 0 || index >= this->length)
+	if (index < 0 || index > OVUM_ISIZE_MAX || (size_t)index >= this->length)
 	{
 		VM_PushString(thread, strings::index);
 		return VM_ThrowErrorOfType(thread, aves->aves.ArgumentRangeError, 1);
 	}
 
-	result = index;
+	result = (size_t)index;
 	RETURN_SUCCESS;
 }
 
@@ -33,7 +33,7 @@ size_t Array::GetSize(int64_t length)
 	// Let's calculate the total number of bytes required for
 	// all the items of the array.
 	int64_t itemsSize;
-	int r = Int_MultiplyChecked(length, sizeof(Value), itemsSize);
+	int r = Int_MultiplyChecked(length, (int64_t)sizeof(Value), itemsSize);
 	if (r != OVUM_SUCCESS)
 		return 0;
 
@@ -83,7 +83,7 @@ AVES_API BEGIN_NATIVE_FUNCTION(aves_Array_new)
 	// unused anyway, and then initialize it.
 	CHECKED(GC_Alloc(thread, aves->aves.Array, size, THISP));
 	Array *array = THISV.Get<Array>();
-	array->length = length;
+	array->length = (size_t)length;
 
 	// And that's it! Let's just return the value.
 	VM_Push(thread, THISP);
@@ -94,7 +94,7 @@ AVES_API BEGIN_NATIVE_FUNCTION(aves_Array_get_item)
 {
 	Array *array = THISV.Get<Array>();
 
-	int64_t index;
+	size_t index;
 	CHECKED(array->GetIndex(thread, args + 1, index));
 
 	VM_Push(thread, &array->firstValue + index);
@@ -105,7 +105,7 @@ AVES_API BEGIN_NATIVE_FUNCTION(aves_Array_set_item)
 {
 	Array *array = THISV.Get<Array>();
 
-	int64_t index;
+	size_t index;
 	CHECKED(array->GetIndex(thread, args + 1, index));
 
 	(&array->firstValue)[index] = args[2];
@@ -126,8 +126,8 @@ AVES_API NATIVE_FUNCTION(aves_Array_fillInternal)
 
 	Array *array = THISV.Get<Array>();
 	Value *value = args + 1;
-	int64_t startIndex = args[2].v.integer;
-	int64_t count = args[3].v.integer;
+	size_t startIndex = (size_t)args[2].v.integer;
+	size_t count = (size_t)args[3].v.integer;
 
 	Value *items = &array->firstValue;
 	while (count > 0)
@@ -146,12 +146,12 @@ AVES_API NATIVE_FUNCTION(aves_Array_copyInternal)
 	// The external methods range-check all the arguments.
 	Array *src = args[0].Get<Array>();
 	Array *dest = args[2].Get<Array>();
-	int64_t srcIndex = args[1].v.integer;
-	int64_t destIndex = args[3].v.integer;
-	int64_t count = args[4].v.integer;
+	size_t srcIndex = (size_t)args[1].v.integer;
+	size_t destIndex = (size_t)args[3].v.integer;
+	size_t count = (size_t)args[4].v.integer;
 
 	// If count fits within the source and destination arrays, it must be small enough for size_t.
-	size_t size = (size_t)count * sizeof(Value);
+	size_t size = count * sizeof(Value);
 	// Copying this data could take a while, if count is particularly large. However, the array
 	// contains managed references, which means we can't enter a native region here: if the GC
 	// runs, the destination array must be in a consistent state.
@@ -166,20 +166,9 @@ int OVUM_CDECL aves_Array_walkReferences(void *basePtr, ReferenceVisitor callbac
 	Array *array = reinterpret_cast<Array*>(basePtr);
 
 	Value *items = &array->firstValue;
-	int64_t length = array->length;
+	size_t length = array->length;
 
-#if OVUM_64BIT
-	// Unlikely case - the array has more than 4 billion entries.
-	// Still, we have to support that as well.
-	while (length > UINT_MAX)
-	{
-		callback(cbState, UINT_MAX, items);
-		items += UINT_MAX;
-		length -= UINT_MAX;
-	}
-#endif
-
-	callback(cbState, (unsigned int)length, items);
+	callback(cbState, length, items);
 
 	RETURN_SUCCESS;
 }

--- a/aves/cpp/aves/array.h
+++ b/aves/cpp/aves/array.h
@@ -9,10 +9,10 @@ namespace aves
 class Array
 {
 public:
-	int64_t length;
+	size_t length;
 	Value firstValue;
 
-	int GetIndex(ThreadHandle thread, Value *arg, int64_t &result);
+	int GetIndex(ThreadHandle thread, Value *arg, size_t &result);
 	static size_t GetSize(int64_t length);
 };
 

--- a/aves/cpp/aves/buffer.h
+++ b/aves/cpp/aves/buffer.h
@@ -5,7 +5,7 @@
 
 typedef struct Buffer_S
 {
-	uint32_t size; // The total number of bytes in the buffer
+	size_t size; // The total number of bytes in the buffer
 	union
 	{
 		uint8_t *bytes;
@@ -54,7 +54,7 @@ AVES_API NATIVE_FUNCTION(aves_Buffer_copyInternal);
 void aves_Buffer_finalize(void *basePtr);
 
 // For other native modules that want a byte pointer from a Buffer
-AVES_API uint8_t *aves_Buffer_getDataPointer(Value *buffer, uint32_t *bufferSize);
+AVES_API uint8_t *aves_Buffer_getDataPointer(Value *buffer, size_t *bufferSize);
 
 
 typedef struct BufferView_S

--- a/aves/cpp/aves/char.cpp
+++ b/aves/cpp/aves/char.cpp
@@ -6,7 +6,7 @@
 
 using namespace aves;
 
-LitString<2> Char::ToLitString(const ovwchar_t ch)
+LitString<2> Char::ToLitString(ovwchar_t ch)
 {
 	LitString<2> output = {
 		ch > 0xFFFF ? 2 : 1,
@@ -214,16 +214,16 @@ AVES_API BEGIN_NATIVE_FUNCTION(aves_Char_opMultiply)
 	int64_t length;
 	if (Int_MultiplyChecked(times, str.length, length))
 		return VM_ThrowOverflowError(thread);
-	if (length > INT32_MAX)
+	if (length > OVUM_ISIZE_MAX)
 	{
 		VM_PushString(thread, strings::times);
 		return VM_ThrowErrorOfType(thread, aves->aves.ArgumentRangeError, 1);
 	}
 
 	StringBuffer buf;
-	CHECKED_MEM(buf.Init((int32_t)length));
+	CHECKED_MEM(buf.Init((size_t)length));
 
-	for (int32_t i = 0; i < (int32_t)length; i++)
+	for (size_t i = 0; i < (size_t)length; i++)
 		CHECKED_MEM(buf.Append(str.AsString()));
 
 	String *result;

--- a/aves/cpp/aves/char.h
+++ b/aves/cpp/aves/char.h
@@ -7,7 +7,7 @@
 class Char
 {
 public:
-	static LitString<2> ToLitString(const ovwchar_t ch);
+	static LitString<2> ToLitString(ovwchar_t ch);
 
 	static ovwchar_t FromValue(Value *value);
 

--- a/aves/cpp/aves/error.cpp
+++ b/aves/cpp/aves/error.cpp
@@ -1,7 +1,6 @@
 #include "error.h"
 #include <ovum_string.h>
 #include <ovum_stringbuffer.h>
-#include <cstddef>
 
 LitString<30> _DefaultErrorMessage = LitString<30>::FromCString("An unspecified error occurred.");
 String *DefaultErrorMessage = _DefaultErrorMessage.AsString();

--- a/aves/cpp/aves/int.h
+++ b/aves/cpp/aves/int.h
@@ -32,23 +32,50 @@ AVES_API NATIVE_FUNCTION(aves_Int_opNot);
 // Internal methods
 namespace integer
 {
-	String *ToString(ThreadHandle thread, const int64_t value,
-		const int radix, const int minWidth,
-		const bool upper);
+	String *ToString(
+		ThreadHandle thread,
+		int64_t value,
+		int radix,
+		size_t minWidth,
+		bool upper
+	);
 
-	int32_t ToStringDecimal(ThreadHandle thread, const int64_t value,
-		const int minWidth,
-		const int bufferSize, ovchar_t *buf);
-	int32_t ToStringHex(ThreadHandle thread, const int64_t value,
-		const bool upper, const int minWidth,
-		const int bufferSize, ovchar_t *buf);
-	int32_t ToStringRadix(ThreadHandle thread, const int64_t value,
-		const int radix, const bool upper, const int minWidth,
-		const int bufferSize, ovchar_t *buf);
+	size_t ToStringDecimal(
+		ThreadHandle thread,
+		int64_t value,
+		size_t minWidth,
+		size_t bufferSize,
+		ovchar_t *buf
+	);
 
-	int ParseFormatString(ThreadHandle thread, String *str, int *radix, int *minWidth, bool *upper);
+	size_t ToStringHex(
+		ThreadHandle thread,
+		int64_t value,
+		bool upper,
+		size_t minWidth,
+		size_t bufferSize,
+		ovchar_t *buf
+	);
 
-	inline int Power(const int64_t base, const int64_t exponent, int64_t &output)
+	size_t ToStringRadix(
+		ThreadHandle thread,
+		int64_t value,
+		int radix,
+		bool upper,
+		size_t minWidth,
+		size_t bufferSize,
+		ovchar_t *buf
+	);
+
+	int ParseFormatString(
+		ThreadHandle thread,
+		String *str,
+		int *radix,
+		size_t *minWidth,
+		bool *upper
+	);
+
+	inline int Power(int64_t base, int64_t exponent, int64_t &output)
 	{
 		int64_t a = base;
 		int64_t b = exponent;

--- a/aves/cpp/aves/list.h
+++ b/aves/cpp/aves/list.h
@@ -28,12 +28,12 @@ AVES_API NATIVE_FUNCTION(aves_List_slice2);
 AVES_API NATIVE_FUNCTION(aves_List_sliceTo);
 AVES_API NATIVE_FUNCTION(aves_List_reverse);
 
-AVES_API int OVUM_CDECL InitListInstance(ThreadHandle thread, ListInst *list, const int32_t capacity);
+AVES_API int OVUM_CDECL InitListInstance(ThreadHandle thread, ListInst *list, size_t capacity);
 
-int EnsureMinCapacity(ThreadHandle thread, ListInst *list, const int32_t capacity);
+int EnsureMinCapacity(ThreadHandle thread, ListInst *list, size_t capacity);
 
-int SetListCapacity(ThreadHandle thread, ListInst *list, const int32_t capacity);
+int SetListCapacity(ThreadHandle thread, ListInst *list, size_t capacity);
 
-int SliceList(ThreadHandle thread, ListInst *list, int32_t startIndex, int32_t endIndex, Value *output);
+int SliceList(ThreadHandle thread, ListInst *list, size_t startIndex, size_t endIndex, Value *output);
 
 #endif // AVES__LIST_H

--- a/aves/cpp/aves/method.cpp
+++ b/aves/cpp/aves/method.cpp
@@ -9,8 +9,7 @@ AVES_API int OVUM_CDECL aves_Method_init(TypeHandle type)
 {
 	Type_SetInstanceSize(type, sizeof(MethodInst));
 
-	int r;
-	r = Type_AddNativeField(type, offsetof(MethodInst, instance), NativeFieldType::VALUE);
+	int r = Type_AddNativeField(type, offsetof(MethodInst, instance), NativeFieldType::VALUE);
 	if (r != OVUM_SUCCESS)
 		return r;
 	RETURN_SUCCESS;
@@ -57,10 +56,10 @@ AVES_API BEGIN_NATIVE_FUNCTION(aves_Method_accepts)
 	CHECKED(IntFromValue(thread, args + 1));
 	int64_t argCount = args[1].v.integer;
 
-	if (argCount < 0 || argCount > INT_MAX)
+	if (argCount < 0 || argCount > OVLOCALS_MAX)
 		VM_PushBool(thread, false);
 	else
-		VM_PushBool(thread, Method_Accepts(method->method, (int)argCount));
+		VM_PushBool(thread, Method_Accepts(method->method, (ovlocals_t)argCount));
 }
 END_NATIVE_FUNCTION
 

--- a/aves/cpp/aves/reflection/field.cpp
+++ b/aves/cpp/aves/reflection/field.cpp
@@ -8,8 +8,7 @@ AVES_API int OVUM_CDECL aves_reflection_Field_init(TypeHandle type)
 {
 	Type_SetInstanceSize(type, sizeof(FieldInst));
 
-	int r;
-	r = Type_AddNativeField(type, offsetof(FieldInst,fullName), NativeFieldType::STRING);
+	int r = Type_AddNativeField(type, offsetof(FieldInst,fullName), NativeFieldType::STRING);
 	if (r != OVUM_SUCCESS)
 		return r;
 	RETURN_SUCCESS;

--- a/aves/cpp/aves/reflection/methodbase.cpp
+++ b/aves/cpp/aves/reflection/methodbase.cpp
@@ -8,8 +8,7 @@ AVES_API int OVUM_CDECL aves_reflection_MethodBase_init(TypeHandle type)
 {
 	Type_SetInstanceSize(type, sizeof(MethodBaseInst));
 
-	int r;
-	r = Type_AddNativeField(type, offsetof(MethodBaseInst,cachedName), NativeFieldType::STRING);
+	int r = Type_AddNativeField(type, offsetof(MethodBaseInst,cachedName), NativeFieldType::STRING);
 	if (r != OVUM_SUCCESS)
 		return r;
 	RETURN_SUCCESS;
@@ -139,9 +138,9 @@ AVES_API NATIVE_FUNCTION(aves_reflection_MethodBase_getOverloadHandle)
 {
 	Aves *aves = Aves::Get(thread);
 
-	// getOverloadHandle(index is Int)
+	// getOverloadHandle(index: Int)
 	MethodBaseInst *inst = THISV.Get<MethodBaseInst>();
-	int32_t index = (int32_t)args[1].v.integer;
+	size_t index = (size_t)args[1].v.integer;
 
 	Value handle;
 	handle.type = aves->aves.reflection.NativeHandle;
@@ -153,19 +152,19 @@ AVES_API NATIVE_FUNCTION(aves_reflection_MethodBase_getOverloadHandle)
 
 AVES_API BEGIN_NATIVE_FUNCTION(aves_reflection_MethodBase_invoke)
 {
-	// invoke(instance, arguments is List|null)
+	// invoke(instance, arguments: List|null)
 
 	MethodBaseInst *inst = THISV.Get<MethodBaseInst>();
 
 	// Push instance
 	VM_Push(thread, args + 1);
 	// Push arguments
-	uint32_t argCount = 0;
+	ovlocals_t argCount = 0;
 	if (!IS_NULL(args[2]))
 	{
 		ListInst *arguments = args[2].v.list;
-		argCount = (uint32_t)arguments->length;
-		for (int32_t i = 0; i < arguments->length; i++)
+		argCount = (ovlocals_t)arguments->length;
+		for (size_t i = 0; i < arguments->length; i++)
 			VM_Push(thread, arguments->values + i);
 	}
 

--- a/aves/cpp/aves/reflection/module.cpp
+++ b/aves/cpp/aves/reflection/module.cpp
@@ -66,7 +66,13 @@ int GetMemberSearchFlags(ThreadHandle thread, Value *arg, uint32_t *result)
 	RETURN_SUCCESS;
 }
 
-bool GetSingleMember(ModuleHandle module, String *name, uint32_t access, uint32_t kind, GlobalMember *result)
+bool GetSingleMember(
+	ModuleHandle module,
+	String *name,
+	uint32_t access,
+	uint32_t kind,
+	GlobalMember *result
+)
 {
 	if (Module_GetGlobalMember(module, name, true, result))
 		return (result->flags & access) != 0 &&
@@ -115,8 +121,13 @@ int ResultToMember(ThreadHandle thread, Value *module, GlobalMember *member)
 	return r;
 }
 
-int GetAllMembers(ThreadHandle thread, ModuleHandle module, Value *moduleValue,
-                  uint32_t access, uint32_t kind)
+int GetAllMembers(
+	ThreadHandle thread,
+	ModuleHandle module,
+	Value *moduleValue,
+	uint32_t access,
+	uint32_t kind
+)
 {
 	int status__;
 	{
@@ -386,7 +397,7 @@ AVES_API BEGIN_NATIVE_FUNCTION(aves_reflection_Module_getSearchDirectories)
 {
 	TempBuffer<String*, 16> searchDirs;
 
-	int dirCount = 0;
+	size_t dirCount = 0;
 	do
 	{
 		CHECKED_MEM(searchDirs.EnsureCapacity(dirCount));
@@ -402,7 +413,7 @@ AVES_API BEGIN_NATIVE_FUNCTION(aves_reflection_Module_getSearchDirectories)
 	VM_PushInt(thread, dirCount); // list capacity
 	CHECKED(GC_Construct(thread, GetType_List(thread), 1, output));
 
-	for (int i = 0; i < dirCount; i++)
+	for (size_t i = 0; i < dirCount; i++)
 	{
 		Value ignore;
 		VM_Push(thread, output);

--- a/aves/cpp/aves/reflection/overload.h
+++ b/aves/cpp/aves/reflection/overload.h
@@ -7,7 +7,7 @@ class OverloadInst
 {
 public:
 	OverloadHandle overload;
-	int32_t index;
+	size_t index;
 	Value method;
 };
 
@@ -30,7 +30,7 @@ class ParamInst
 {
 public:
 	ParamInfo param;
-	int32_t index;
+	ovlocals_t index;
 	Value overload;
 };
 

--- a/aves/cpp/aves/reflection/property.cpp
+++ b/aves/cpp/aves/reflection/property.cpp
@@ -8,8 +8,7 @@ AVES_API int OVUM_CDECL aves_reflection_Property_init(TypeHandle type)
 {
 	Type_SetInstanceSize(type, sizeof(PropertyInst));
 
-	int r;
-	r = Type_AddNativeField(type, offsetof(PropertyInst,fullName), NativeFieldType::STRING);
+	int r = Type_AddNativeField(type, offsetof(PropertyInst,fullName), NativeFieldType::STRING);
 	if (r != OVUM_SUCCESS)
 		return r;
 	RETURN_SUCCESS;

--- a/aves/cpp/aves/reflection/type.cpp
+++ b/aves/cpp/aves/reflection/type.cpp
@@ -294,16 +294,16 @@ AVES_API BEGIN_NATIVE_FUNCTION(aves_reflection_Type_createInstance)
 		return VM_ThrowErrorOfType(thread, aves->aves.InvalidStateError, 0);
 
 	// Push arguments
-	uint32_t argCount = 0;
+	ovlocals_t argCount = 0;
 	if (!IS_NULL(args[1]))
 	{
 		ListInst *arguments = args[1].v.list;
-		argCount = (uint32_t)arguments->length;
-		for (int32_t i = 0; i < arguments->length; i++)
+		argCount = (ovlocals_t)arguments->length;
+		for (size_t i = 0; i < arguments->length; i++)
 			VM_Push(thread, arguments->values + i);
 	}
 
-	CHECKED(GC_Construct(thread, inst->type, (uint16_t)argCount, nullptr));
+	CHECKED(GC_Construct(thread, inst->type, argCount, nullptr));
 }
 END_NATIVE_FUNCTION
 

--- a/aves/cpp/aves/set.h
+++ b/aves/cpp/aves/set.h
@@ -8,26 +8,50 @@ namespace aves
 
 struct SetEntry
 {
+	// Lower 31 bits of hash code. If the bucket used to contain a value that
+	// has since been removed, contains REMOVED.
 	int32_t hashCode;
-	int32_t next;
+	// Index of next entry in bucket. If this is the last entry in the bucket,
+	// has the value Set::LAST.
+	size_t next;
 	Value value;
+
+	inline bool IsRemoved() const
+	{
+		return hashCode == REMOVED;
+	}
+
+	// When the hash code of an entry is set to this value, indicates that
+	// it used to contain a value that has since been removed.
+	static const int32_t REMOVED = -1;
 };
 
 class Set
 {
 public:
-	int32_t capacity;   // the number of "slots" in buckets, entries and values
-	int32_t count;      // the number of entries (not buckets) that have been used
-	int32_t freeCount;  // the number of entries that were previously used, and have now been freed (and can thus be reused)
-	int32_t freeList;   // the index of the first freed entry
-	int32_t version;    // the "version" of the hash, incremented whenever changes are made
+	static const size_t LAST = (size_t)-1;
 
-	int32_t *buckets;   // indexes into entries
-	SetEntry *entries;  // entries!
+	// The number of "slots" in buckets and entries.
+	size_t capacity;
+	// The number of entries (not buckets) that have been used.
+	size_t count;
+	// The number of entries that were previously used, and have now been freed
+	// (and can thus be reused).
+	size_t freeCount;
+	// The index of the first freed entry. If the free list is empty, has the
+	// value LAST.
+	size_t freeList;
+	// The "version" of the set, incremented whenever changes are made.
+	int32_t version;
+
+	// Indexes into entries.
+	size_t *buckets;
+	// The actual values stored in the set.
+	SetEntry *entries;
 
 	Value itemComparer;
 
-	int InitializeBuckets(ThreadHandle thread, int32_t capacity);
+	int InitializeBuckets(ThreadHandle thread, size_t capacity);
 
 	int Resize(ThreadHandle thread);
 

--- a/aves/cpp/aves/string.h
+++ b/aves/cpp/aves/string.h
@@ -98,14 +98,29 @@ namespace unicode
 
 namespace string
 {
-	int32_t IndexOf(const String *str, const String *part, int32_t startIndex, int32_t count);
-	int32_t LastIndexOf(const String *str, const String *part);
+	const size_t NOT_FOUND = (size_t)-1;
+
+	size_t IndexOf(const String *str, const String *part, size_t startIndex, size_t count);
+
+	size_t LastIndexOf(const String *str, const String *part);
 
 	int Format(ThreadHandle thread, const String *format, ListInst *list, String *&result);
 	int Format(ThreadHandle thread, const String *format, Value *hash, String *&result);
 
-	String *Replace(ThreadHandle thread, String *input, const ovchar_t oldChar, const ovchar_t newChar, const int64_t maxTimes);
-	String *Replace(ThreadHandle thread, String *input, String *oldValue, String *newValue, const int64_t maxTimes);
+	String *Replace(
+		ThreadHandle thread,
+		String *input,
+		ovchar_t oldChar,
+		ovchar_t newChar,
+		int64_t maxTimes
+	);
+	String *Replace(
+		ThreadHandle thread,
+		String *input,
+		String *oldValue,
+		String *newValue,
+		int64_t maxTimes
+	);
 }
 
 #endif // AVES__STRING_H

--- a/aves/cpp/aves/uint.h
+++ b/aves/cpp/aves/uint.h
@@ -29,20 +29,42 @@ AVES_API NATIVE_FUNCTION(aves_UInt_opNot);
 // Internal methods
 namespace uinteger
 {
-	String *ToString(ThreadHandle thread, const uint64_t value,
-		const int radix, const int minWidth, const bool upper);
+	String *ToString(
+		ThreadHandle thread,
+		uint64_t value,
+		int radix,
+		size_t minWidth,
+		bool upper
+	);
 
-	int32_t ToStringDecimal(ThreadHandle thread, const uint64_t value,
-		const int minWidth,
-		const int bufferSize, ovchar_t *buf);
-	int32_t ToStringHex(ThreadHandle thread, const uint64_t value,
-		const bool upper, const int minWidth,
-		const int bufferSize, ovchar_t *buf);
-	int32_t ToStringRadix(ThreadHandle thread, const uint64_t value,
-		const int radix, const bool upper, const int minWidth,
-		const int bufferSize, ovchar_t *buf);
+	size_t ToStringDecimal(
+		ThreadHandle thread,
+		uint64_t value,
+		size_t minWidth,
+		size_t bufferSize,
+		ovchar_t *buf
+	);
 
-	inline int Power(const uint64_t base, const uint64_t exponent, uint64_t &output)
+	size_t ToStringHex(
+		ThreadHandle thread,
+		uint64_t value,
+		bool upper,
+		size_t minWidth,
+		size_t bufferSize,
+		ovchar_t *buf
+	);
+
+	size_t ToStringRadix(
+		ThreadHandle thread,
+		uint64_t value,
+		int radix,
+		bool upper,
+		size_t minWidth,
+		size_t bufferSize,
+		ovchar_t *buf
+	);
+
+	inline int Power(uint64_t base, uint64_t exponent, uint64_t &output)
 	{
 		uint64_t a = base;
 		uint64_t b = exponent;

--- a/aves/cpp/aves/utf16encoding.h
+++ b/aves/cpp/aves/utf16encoding.h
@@ -35,8 +35,9 @@ public:
 	// All strings are already UTF-16, so we can just write the UTF-16
 	// code units straight to the buffer.
 
-	int32_t GetByteCount(ThreadHandle thread, String *str, bool flush);
-	int32_t GetBytes(ThreadHandle thread, String *str, Buffer *buf, int32_t offset, bool flush);
+	ssize_t GetByteCount(ThreadHandle thread, String *str, bool flush);
+
+	ssize_t GetBytes(ThreadHandle thread, String *str, Buffer *buf, size_t offset, bool flush);
 
 	inline void Reset() { }
 };
@@ -66,8 +67,9 @@ public:
 	bool hasPrevByte;
 	uint8_t prevByte;
 
-	int32_t GetCharCount(ThreadHandle thread, Buffer *buf, int32_t offset, int32_t count, bool flush);
-	int32_t GetChars(ThreadHandle thread, Buffer *buf, int32_t offset, int32_t count, StringBuffer *sb, bool flush);
+	ssize_t GetCharCount(ThreadHandle thread, Buffer *buf, size_t offset, size_t count, bool flush);
+
+	ssize_t GetChars(ThreadHandle thread, Buffer *buf, size_t offset, size_t count, StringBuffer *sb, bool flush);
 
 	void Reset();
 

--- a/aves/cpp/aves/utf8encoding.h
+++ b/aves/cpp/aves/utf8encoding.h
@@ -47,12 +47,13 @@ public:
 	// something.
 	ovchar_t surrogateChar;
 
-	int32_t GetByteCount(ThreadHandle thread, String *str, bool flush);
-	int32_t GetBytes(ThreadHandle thread, String *str, Buffer *buf, int32_t offset, bool flush);
+	ssize_t GetByteCount(ThreadHandle thread, String *str, bool flush);
+
+	ssize_t GetBytes(ThreadHandle thread, String *str, Buffer *buf, size_t offset, bool flush);
 
 	void Reset();
 
-	static int BufferOverrunError(ThreadHandle thread);
+	static ssize_t BufferOverrunError(ThreadHandle thread);
 };
 
 AVES_API int aves_Utf8Encoder_init(TypeHandle type);
@@ -103,8 +104,9 @@ public:
 		uint32_t bytesLeftAll;
 	};
 
-	int32_t GetCharCount(ThreadHandle thread, Buffer *buf, int32_t offset, int32_t count, bool flush);
-	int32_t GetChars(ThreadHandle thread, Buffer *buf, int32_t offset, int32_t count, StringBuffer *sb, bool flush);
+	ssize_t GetCharCount(ThreadHandle thread, Buffer *buf, size_t offset, size_t count, bool flush);
+
+	ssize_t GetChars(ThreadHandle thread, Buffer *buf, size_t offset, size_t count, StringBuffer *sb, bool flush);
 
 	void Reset();
 
@@ -118,10 +120,10 @@ AVES_API NATIVE_FUNCTION(aves_Utf8Decoder_getCharsInternal);
 AVES_API NATIVE_FUNCTION(aves_Utf8Decoder_reset);
 
 // Some native APIs!
-AVES_API int32_t aves_GetUtf8ByteCount(ThreadHandle thread, String *str);
-AVES_API int32_t aves_GetUtf8Bytes(ThreadHandle thread, String *str, uint8_t *buffer, uint32_t bufSize, int32_t offset);
+AVES_API ssize_t aves_GetUtf8ByteCount(ThreadHandle thread, String *str);
+AVES_API ssize_t aves_GetUtf8Bytes(ThreadHandle thread, String *str, uint8_t *buffer, size_t bufSize, size_t offset);
 
-AVES_API int32_t aves_GetUtf8CharCount(ThreadHandle thread, uint8_t *buffer, uint32_t bufSize, int32_t offset, int32_t count);
-AVES_API int32_t aves_GetUtf8Chars(ThreadHandle thread, uint8_t *buffer, uint32_t bufSize, int32_t offset, int32_t count, StringBuffer *sb);
+AVES_API ssize_t aves_GetUtf8CharCount(ThreadHandle thread, uint8_t *buffer, size_t bufSize, size_t offset, size_t count);
+AVES_API ssize_t aves_GetUtf8Chars(ThreadHandle thread, uint8_t *buffer, size_t bufSize, size_t offset, size_t count, StringBuffer *sb);
 
 #endif // AVES__UTF8ENCODING

--- a/aves/cpp/io/path.h
+++ b/aves/cpp/io/path.h
@@ -19,24 +19,26 @@ public:
 
 	static LitString<1> DirSeparatorString;
 
-	static const int InvalidPathCharsCount;
+	static const size_t InvalidPathCharsCount;
 	static const ovchar_t InvalidPathChars[];
 
-	static const int InvalidFileNameCharsCount;
+	static const size_t InvalidFileNameCharsCount;
 	static const ovchar_t InvalidFileNameChars[];
+
+	static const size_t NOT_FOUND = (size_t)-1;
 
 	inline static bool IsPathSep(ovchar_t ch)
 	{
 		return ch == DirSeparator || ch == AltDirSeparator;
 	}
 
-	static int32_t GetExtensionIndex(String *path);
+	static size_t GetExtensionIndex(String *path);
 
 	static bool IsAbsolute(String *path);
 
 	static int GetFullPath(ThreadHandle thread, String *path, String **result);
 
-	static int32_t GetRootLength(String *path);
+	static size_t GetRootLength(String *path);
 
 	static int ValidatePath(ThreadHandle thread, String *path, bool checkWildcards);
 };

--- a/aves/cpp/io/textreader.cpp
+++ b/aves/cpp/io/textreader.cpp
@@ -11,8 +11,6 @@ namespace strings
 MethodHandle TextReaderInst::FillBuffer;
 String *TextReaderInst::FillBufferName = strings::_FillBufferName.AsString();
 
-#define _TR(val)     reinterpret_cast<TextReaderInst*>((val).instance)
-
 AVES_API int OVUM_CDECL io_TextReader_init(TypeHandle type)
 {
 	Type_SetInstanceSize(type, sizeof(TextReaderInst));
@@ -112,28 +110,28 @@ AVES_API NATIVE_FUNCTION(io_TextReader_set_charBuffer)
 AVES_API NATIVE_FUNCTION(io_TextReader_get_charCount)
 {
 	TextReaderInst *tr = THISV.Get<TextReaderInst>();
-	VM_PushInt(thread, tr->charCount);
+	VM_PushInt(thread, (int64_t)tr->charCount);
 	RETURN_SUCCESS;
 }
 AVES_API BEGIN_NATIVE_FUNCTION(io_TextReader_set_charCount)
 {
 	CHECKED(IntFromValue(thread, args + 1));
 	TextReaderInst *tr = THISV.Get<TextReaderInst>();
-	tr->charCount = (int32_t)args[1].v.integer;
+	tr->charCount = (size_t)args[1].v.integer;
 }
 END_NATIVE_FUNCTION
 
 AVES_API NATIVE_FUNCTION(io_TextReader_get_charOffset)
 {
 	TextReaderInst *tr = THISV.Get<TextReaderInst>();
-	VM_PushInt(thread, tr->charOffset);
+	VM_PushInt(thread, (int64_t)tr->charOffset);
 	RETURN_SUCCESS;
 }
 AVES_API BEGIN_NATIVE_FUNCTION(io_TextReader_set_charOffset)
 {
 	CHECKED(IntFromValue(thread, args + 1));
 	TextReaderInst *tr = THISV.Get<TextReaderInst>();
-	tr->charOffset = (int32_t)args[1].v.integer;
+	tr->charOffset = (size_t)args[1].v.integer;
 }
 END_NATIVE_FUNCTION
 
@@ -163,7 +161,7 @@ AVES_API BEGIN_NATIVE_FUNCTION(io_TextReader_readLine)
 	StringBuffer sb; // Initialize on demand only
 	do
 	{
-		int32_t i = tr->charOffset;
+		size_t i = tr->charOffset;
 		do
 		{
 			ovchar_t ch = cb->GetDataPointer()[i];
@@ -171,7 +169,7 @@ AVES_API BEGIN_NATIVE_FUNCTION(io_TextReader_readLine)
 			{
 				// We found a line ending! Make sure a string is
 				// stored in sb.
-				int32_t length = i - tr->charOffset;
+				size_t length = i - tr->charOffset;
 				if (sb.GetDataPointer() == nullptr)
 					CHECKED_MEM(sb.Init(length));
 

--- a/aves/cpp/io/textreader.h
+++ b/aves/cpp/io/textreader.h
@@ -15,8 +15,8 @@ public:
 	Value byteBuffer;   // aves.Buffer
 	Value charBuffer;   // aves.StringBuffer
 	// Not these, however!
-	int32_t charCount;
-	int32_t charOffset;
+	size_t charCount;
+	size_t charOffset;
 	bool keepOpen;
 
 	static MethodHandle FillBuffer;

--- a/aves/cpp/os/windows/windows.h
+++ b/aves/cpp/os/windows/windows.h
@@ -15,6 +15,10 @@
 // Windows header files
 #include <windows.h>
 
+// The ssize_t type is POSIX-specific, but it's also quite useful.
+// Define it here.
+typedef SSIZE_T ssize_t;
+
 // Helper functions
 namespace win32_helpers
 {

--- a/aves/cpp/tempbuffer.h
+++ b/aves/cpp/tempbuffer.h
@@ -33,7 +33,7 @@ namespace aves
 			return stackItems[index];
 		}
 
-		inline T *GetPointer() const
+		inline T *GetPointer()
 		{
 			if (heapItems != nullptr)
 				return heapItems;

--- a/ovum-vm/inc/ovum.h
+++ b/ovum-vm/inc/ovum.h
@@ -120,6 +120,8 @@ typedef uint16_t ovchar_t;
 // be used for argument counts.
 typedef uint32_t ovlocals_t;
 
+#define OVLOCALS_MAX UINT32_MAX
+
 typedef struct Value_S Value;
 typedef struct String_S String;
 typedef struct ListInst_S ListInst;
@@ -219,10 +221,10 @@ OVUM_ENUM_OPS(StringFlags, uint32_t);
 struct String_S
 {
 	// The length of the string, not including the terminating \0.
-	const int32_t length;
+	const size_t length;
 	// The string's hash code. If the string has had its hash code calculated (if the
 	// flag StringFlags::HASHED is set), then this field contains the hash code of the
-	// string. Otherwise, this value is nonsensical.
+	// string. Otherwise, this value is meaningless.
 	int32_t hashCode;
 	// If the flags contain StringFlags::STATIC, the String is never garbage collected,
 	// as it comes from a static resource.
@@ -235,8 +237,8 @@ struct String_S
 
 struct ListInst_S
 {
-	int32_t capacity; // the length of 'values'
-	int32_t length;   // the actual number of items contained in the list
+	size_t capacity; // the length of 'values'
+	size_t length;   // the actual number of items contained in the list
 	int32_t version;  // the "version" of the list, which is incremented each time the list changes
 	Value *values;    // the values contained in the list
 };
@@ -270,8 +272,8 @@ OVUM_API void VM_PrintLn(String *str);
 OVUM_API void VM_PrintErr(String *str);
 OVUM_API void VM_PrintErrLn(String *str);
 
-OVUM_API int VM_GetArgCount(ThreadHandle thread);
-OVUM_API int VM_GetArgs(ThreadHandle thread, int destLength, String *dest[]);
-OVUM_API int VM_GetArgValues(ThreadHandle thread, int destLength, Value dest[]);
+OVUM_API size_t VM_GetArgCount(ThreadHandle thread);
+OVUM_API size_t VM_GetArgs(ThreadHandle thread, size_t destLength, String *dest[]);
+OVUM_API size_t VM_GetArgValues(ThreadHandle thread, size_t destLength, Value dest[]);
 
 #endif // OVUM__VM_H

--- a/ovum-vm/inc/ovum_compat.h
+++ b/ovum-vm/inc/ovum_compat.h
@@ -5,7 +5,7 @@
  * This file contains various compatibility and utility macros.
  */
 
-// All parts of Ovum require standard integer types
+// All parts of Ovum require standard, fixed-size integer types
 #include <stdint.h>
 
 // OVUM_64BIT is true if Ovum is compiled as a 64-bit application
@@ -23,7 +23,7 @@
 #  if __x86_64__ || __ppc64__
 #   define OVUM_64BIT 1
 #  else
-#   define OVUM_64BIT
+#   define OVUM_64BIT 0
 #  endif
 
 # else
@@ -31,6 +31,27 @@
 # endif
 
 #endif // OVUM_64BIT
+
+// Ovum uses size_t to count most things, but Osprey APIs typically use
+// 64-bit signed integers. The OVUM_ISIZE_MAX constant represents a kind
+// of compromise: if SIZE_MAX is less than INT64_MAX (as is the case on
+// 32-bit), it is set to SIZE_MAX; otherwise (as happens on 64-bit, where
+// SIZE_MAX == UINT64_MAX), it expands to INT64_MAX.
+//
+// The purpose of this constant, therefore, is to give you something to
+// range check against when you need compatibility with both size_t and
+// aves.Int.
+//
+// In practice, INT64_MAX should be enough memory under all conceivable
+// circumstances, being equal to about 9223 petabytes.
+
+#ifndef OVUM_ISIZE_MAX
+# if SIZE_MAX > INT64_MAX
+#  define OVUM_ISIZE_MAX INT64_MAX
+# else
+#  define OVUM_ISIZE_MAX SIZE_MAX
+# endif
+#endif // OVUM_ISIZE_MAX
 
 // The OVUM_WCHAR_SIZE macro is used in various text functions
 

--- a/ovum-vm/inc/ovum_gc.h
+++ b/ovum-vm/inc/ovum_gc.h
@@ -23,7 +23,7 @@ OVUM_API int GC_Construct(ThreadHandle thread, TypeHandle type, ovlocals_t argc,
 // Returns null if the string could not be constructed.
 //
 // NOTE: 'length' does NOT include the terminating '\0'.
-OVUM_API String *GC_ConstructString(ThreadHandle thread, int32_t length, const ovchar_t *values);
+OVUM_API String *GC_ConstructString(ThreadHandle thread, size_t length, const ovchar_t *values);
 
 // Allocates a managed value of the specified type and size. Unlike GC_Construct, this
 // function does NOT call the constructor on the allocated value. Moreover, the size of
@@ -66,10 +66,10 @@ OVUM_API int GC_Alloc(ThreadHandle thread, TypeHandle type, size_t size, Value *
 //     The size, in bytes, of each item.
 //   output:
 //     A pointer that receives the resulting array.
-OVUM_API int GC_AllocArray(ThreadHandle thread, uint32_t length, size_t itemSize, void **output);
+OVUM_API int GC_AllocArray(ThreadHandle thread, size_t length, size_t itemSize, void **output);
 
 template<typename T>
-int GC_AllocArrayT(ThreadHandle thread, uint32_t length, T **output)
+int GC_AllocArrayT(ThreadHandle thread, size_t length, T **output)
 {
 	return GC_AllocArray(thread, length, sizeof(T), reinterpret_cast<void**>(output));
 }
@@ -84,7 +84,7 @@ int GC_AllocArrayT(ThreadHandle thread, uint32_t length, T **output)
 //     The number of items the array will contain.
 //   output:
 //     A pointer that receives the resulting array.
-OVUM_API int GC_AllocValueArray(ThreadHandle thread, uint32_t length, Value **output);
+OVUM_API int GC_AllocValueArray(ThreadHandle thread, size_t length, Value **output);
 
 // Informs the GC that a certain amount of unmanaged memory has been allocated,
 // which helps the GC better schedule garbage collection.

--- a/ovum-vm/inc/ovum_helpers.h
+++ b/ovum-vm/inc/ovum_helpers.h
@@ -383,6 +383,6 @@ inline int Int_ModuloChecked(int64_t left, int64_t right, int64_t &result)
 
 // Gets the next prime number greater than or equal to the given value.
 // The prime number is suitable for use as the size of a hash table.
-OVUM_API int32_t HashHelper_GetPrime(int32_t min);
+OVUM_API size_t HashHelper_GetPrime(size_t min);
 
 #endif // OVUM__HELPERS_H

--- a/ovum-vm/inc/ovum_module.h
+++ b/ovum-vm/inc/ovum_module.h
@@ -131,14 +131,14 @@ OVUM_API void Module_InitStaticState(ModuleHandle module, void *state, StaticSta
 OVUM_API bool Module_GetGlobalMember(ModuleHandle module, String *name, bool includeInternal, GlobalMember *result);
 
 // Gets the total number of members in the module.
-OVUM_API int32_t Module_GetGlobalMemberCount(ModuleHandle module);
+OVUM_API size_t Module_GetGlobalMemberCount(ModuleHandle module);
 
 // Gets the global member at the specified index. The index must be between zero (inclusive)
 // and the global member count (exclusive). Module_GetGlobalMemberCount returns the latter.
 //
 // If the index is valid, 'result' is updated with the result, and the function returns true.
 // Otherwise, the function returns false and 'result' is not written to.
-OVUM_API bool Module_GetGlobalMemberByIndex(ModuleHandle module, int32_t index, GlobalMember *result);
+OVUM_API bool Module_GetGlobalMemberByIndex(ModuleHandle module, size_t index, GlobalMember *result);
 
 // Searches a module for a type with the specified name.
 // If the type could not be found, or if the type is private and includeInternal is false,
@@ -187,7 +187,7 @@ OVUM_API ModuleHandle Module_FindDependency(ModuleHandle module, String *name);
 //     the buffer, it must be resized before all directories can be obtained.
 // Returns:
 //   An Ovum status code. This function can fail with an out-of-memory error.
-OVUM_API int Module_GetSearchDirectories(ThreadHandle thread, int resultSize, String **result, int *count);
+OVUM_API int Module_GetSearchDirectories(ThreadHandle thread, size_t resultSize, String **result, size_t *count);
 
 #ifdef __cplusplus
 
@@ -195,7 +195,7 @@ class ModuleMemberIterator
 {
 private:
 	ModuleHandle module;
-	int32_t index;
+	size_t index;
 	GlobalMember current;
 
 public:

--- a/ovum-vm/inc/ovum_string.h
+++ b/ovum-vm/inc/ovum_string.h
@@ -4,12 +4,12 @@
 #include "ovum.h"
 
 OVUM_API int32_t String_GetHashCode(String *str);
-OVUM_API int32_t String_GetHashCodeSubstr(const String *str, int32_t index, int32_t count);
+OVUM_API int32_t String_GetHashCodeSubstr(const String *str, size_t index, size_t count);
 
 OVUM_API bool String_Equals(const String *a, const String *b);
 OVUM_API bool String_EqualsIgnoreCase(const String *a, const String *b);
 
-OVUM_API bool String_SubstringEquals(const String *str, int32_t startIndex, const String *part);
+OVUM_API bool String_SubstringEquals(const String *str, size_t startIndex, const String *part);
 
 OVUM_API int String_Compare(const String *a, const String *b);
 
@@ -24,7 +24,7 @@ inline bool String_EndsWith(const String *a, ovchar_t ch)
 
 inline bool String_ContainsChar(const String *str, ovchar_t ch)
 {
-	for (int32_t i = 0; i < str->length; i++)
+	for (size_t i = 0; i < str->length; i++)
 		if ((&str->firstChar)[i] == ch)
 			return true;
 	return false;
@@ -37,7 +37,7 @@ OVUM_API String *String_ToLower(ThreadHandle thread, String *str);
 
 OVUM_API String *String_Concat(ThreadHandle thread, const String *a, const String *b);
 OVUM_API String *String_Concat3(ThreadHandle thread, const String *a, const String *b, const String *c);
-OVUM_API String *String_ConcatRange(ThreadHandle thread, int count, String *values[]);
+OVUM_API String *String_ConcatRange(ThreadHandle thread, size_t count, String *values[]);
 
 // Converts a String* to a zero-terminated wchar_t* string.
 //   dest:
@@ -51,7 +51,7 @@ OVUM_API String *String_ConcatRange(ThreadHandle thread, int count, String *valu
 //     including the terminating \0.
 //
 // NOTE: the source string may contain \0 characters. These are NOT stripped!
-OVUM_API int32_t String_ToWString(wchar_t *dest, const String *source);
+OVUM_API size_t String_ToWString(wchar_t *dest, const String *source);
 
 // Converts a zero-terminated char* string to a String*.
 //   thread:

--- a/ovum-vm/inc/ovum_stringbuffer.h
+++ b/ovum-vm/inc/ovum_stringbuffer.h
@@ -12,15 +12,16 @@
 class StringBuffer
 {
 private:
-	int32_t capacity;
-	int32_t length;
+	size_t capacity;
+	size_t length;
 	ovchar_t *data;
 
 	static const size_t DefaultCapacity = 128;
 
 public:
-	inline StringBuffer()
-		 : length(0), data(nullptr)
+	inline StringBuffer() :
+		length(0),
+		data(nullptr)
 	{ }
 	inline ~StringBuffer()
 	{
@@ -29,16 +30,24 @@ public:
 		data = nullptr;
 	}
 
-	inline bool Init(int32_t capacity = DefaultCapacity)
+	inline bool Init(size_t capacity = DefaultCapacity)
 	{
 		return SetCapacity(capacity);
 	}
 
-	inline int32_t GetLength() const   { return this->length; }
-	inline int32_t GetCapacity() const { return this->capacity; }
-	inline bool SetCapacity(int32_t newCapacity)
+	inline size_t GetLength() const
 	{
-		int32_t newCap = newCapacity;
+		return this->length;
+	}
+
+	inline size_t GetCapacity() const
+	{
+		return this->capacity;
+	}
+
+	inline bool SetCapacity(size_t newCapacity)
+	{
+		size_t newCap = newCapacity;
 		if (newCap < this->length)
 			newCap = this->length;
 
@@ -54,18 +63,22 @@ public:
 		return true;
 	}
 
-	inline ovchar_t *GetDataPointer() const { return this->data; }
+	inline ovchar_t *GetDataPointer() const
+	{
+		return this->data;
+	}
 
-	inline bool Append(const ovchar_t ch)
+	inline bool Append(ovchar_t ch)
 	{
 		return Append(1, &ch);
 	}
-	inline bool Append(const int32_t count, const ovchar_t ch)
+	inline bool Append(size_t count, const ovchar_t ch)
 	{
-		if (!EnsureMinCapacity(count)) return false;
+		if (!EnsureMinCapacity(count))
+			return false;
 
 		ovchar_t *chp = this->data + this->length;
-		for (int32_t i = 0; i < count; i++)
+		for (size_t i = 0; i < count; i++)
 		{
 			*chp = ch;
 			chp++;
@@ -73,7 +86,7 @@ public:
 		this->length += count;
 		return true;
 	}
-	inline bool Append(const int32_t length, const ovchar_t data[])
+	inline bool Append(size_t length, const ovchar_t data[])
 	{
 		if (!EnsureMinCapacity(length)) return false;
 
@@ -86,12 +99,12 @@ public:
 		return Append(str->length, &str->firstChar);
 	}
 
-	inline bool Append(const int32_t length, const char data[])
+	inline bool Append(size_t length, const char data[])
 	{
 		if (!EnsureMinCapacity(length)) return false;
 
 		ovchar_t *chp = this->data + this->length;
-		for (int32_t i = 0; i < length; i++)
+		for (size_t i = 0; i < length; i++)
 		{
 			*chp = data[i];
 			chp++;
@@ -100,7 +113,7 @@ public:
 		return true;
 	}
 
-	inline bool Insert(const int32_t index, const int32_t length, const ovchar_t data[])
+	inline bool Insert(size_t index, size_t length, const ovchar_t data[])
 	{
 		if (length > 0)
 		{
@@ -109,7 +122,7 @@ public:
 			ovchar_t *destp = this->data + this->length + length - 1;
 			const ovchar_t *srcp = this->data + this->length - 1;
 
-			int32_t remaining = this->length - index;
+			size_t remaining = this->length - index;
 			while (remaining--)
 				*destp-- = *srcp--;
 
@@ -117,11 +130,11 @@ public:
 		}
 		return true;
 	}
-	inline bool Insert(const int32_t index, const ovchar_t data)
+	inline bool Insert(size_t index, ovchar_t data)
 	{
 		return Insert(index, 1, &data);
 	}
-	inline bool Insert(const int32_t index, String *str)
+	inline bool Insert(size_t index, String *str)
 	{
 		return Insert(index, str->length, &str->firstChar);
 	}
@@ -132,11 +145,11 @@ public:
 		this->length = 0;
 	}
 
-	inline bool StartsWith(const ovchar_t ch) const
+	inline bool StartsWith(ovchar_t ch) const
 	{
 		return this->length > 0 && this->data[0] == ch;
 	}
-	inline bool EndsWith(const ovchar_t ch) const
+	inline bool EndsWith(ovchar_t ch) const
 	{
 		return this->length > 0 && this->data[this->length - 1] == ch;
 	}
@@ -148,13 +161,13 @@ public:
 
 	// If buf is null, returns only the size of the resulting string,
 	// including the terminating \0.
-	inline int ToWString(wchar_t *buf)
+	inline size_t ToWString(wchar_t *buf)
 	{
 		// This is basically copied straight from String_ToWString, but optimized for StringBuffer.
 #if OVUM_WCHAR_SIZE == 2
 		// UTF-16 (or at least UCS-2, but hopefully surrogates won't break things too much)
 
-		int outputLength = this->length; // Do NOT include the \0
+		size_t outputLength = this->length; // Do NOT include the \0
 
 		if (buf)
 		{
@@ -169,11 +182,11 @@ public:
 		// First, iterate over the string to find out how many surrogate pairs there are,
 		// if any. These consume only one UTF-32 character.
 		// We use this to calculate the length of the output (including the \0).
-		int outputLength = 0;
+		size_t outputLength = 0;
 
-		int32_t strLen = this->length; // let's NOT include the \0
+		size_t strLen = this->length; // let's NOT include the \0
 		const ovchar_t *strp = this->data;
-		for (int32_t i = 0; i < strLen; i++)
+		for (size_t i = 0; i < strLen; i++)
 		{
 			if (UC_IsSurrogateLead(*strp) && UC_IsSurrogateTrail(*(strp + 1)))
 			{
@@ -190,7 +203,7 @@ public:
 			strp = this->data;
 
 			wchar_t *outp = buf;
-			for (int i = 0; i < outputLength; i++)
+			for (size_t i = 0; i < outputLength; i++)
 			{
 				if (UC_IsSurrogateLead(*strp) && UC_IsSurrogateTrail(*(strp + 1)))
 				{
@@ -215,7 +228,7 @@ public:
 	}
 
 private:
-	inline bool EnsureMinCapacity(int32_t newAmount)
+	inline bool EnsureMinCapacity(size_t newAmount)
 	{
 		if (INT32_MAX - newAmount < this->length)
 			return false;
@@ -223,7 +236,7 @@ private:
 		if (this->length + newAmount > this->capacity)
 		{
 			// Double the capacity, but make sure newAmount will actually fit too
-			int32_t newLength = this->length << 1;
+			size_t newLength = this->length << 1;
 			if (newLength < this->length + newAmount)
 				newLength += newAmount;
 			return SetCapacity(newLength);

--- a/ovum-vm/inc/ovum_unicode.h
+++ b/ovum-vm/inc/ovum_unicode.h
@@ -179,7 +179,7 @@ inline SurrogatePair UC_ToSurrogatePair(ovwchar_t ch)
 
 // UTF-16 array functions
 
-inline UnicodeCategory UC_GetCategory(const ovchar_t chars[], unsigned int index, bool *wasSurrogatePair)
+inline UnicodeCategory UC_GetCategory(const ovchar_t chars[], size_t index, bool *wasSurrogatePair)
 {
 	const ovchar_t first = chars[index];
 	*wasSurrogatePair = UC_IsSurrogateLead(first) && UC_IsSurrogateTrail(chars[index + 1]);
@@ -188,13 +188,13 @@ inline UnicodeCategory UC_GetCategory(const ovchar_t chars[], unsigned int index
 	else
 		return UC_GetCategory(first);
 }
-inline UnicodeCategory UC_GetCategory(const ovchar_t chars[], unsigned int index)
+inline UnicodeCategory UC_GetCategory(const ovchar_t chars[], size_t index)
 {
 	bool ignore;
 	return UC_GetCategory(chars, index, &ignore);
 }
 
-inline bool UC_IsCategory(const ovchar_t chars[], unsigned int index, UnicodeCategory cat, bool *wasSurrogatePair)
+inline bool UC_IsCategory(const ovchar_t chars[], size_t index, UnicodeCategory cat, bool *wasSurrogatePair)
 {
 	UnicodeCategory charCat = UC_GetCategory(chars, index, wasSurrogatePair);
 	if ((cat & UC_SUB_CATEGORY_MASK) == 0)
@@ -202,27 +202,27 @@ inline bool UC_IsCategory(const ovchar_t chars[], unsigned int index, UnicodeCat
 	else
 		return charCat == cat;
 }
-inline bool UC_IsCategory(const ovchar_t chars[], unsigned int index, UnicodeCategory cat)
+inline bool UC_IsCategory(const ovchar_t chars[], size_t index, UnicodeCategory cat)
 {
 	bool ignore;
 	return UC_IsCategory(chars, index, cat, &ignore);
 }
 
-inline bool UC_IsUpper(const ovchar_t chars[], unsigned int index, bool *wasSurrogatePair)
+inline bool UC_IsUpper(const ovchar_t chars[], size_t index, bool *wasSurrogatePair)
 {
 	return UC_IsCategory(chars, index, UC_LETTER_UPPERCASE, wasSurrogatePair);
 }
-inline bool UC_IsUpper(const ovchar_t chars[], unsigned int index)
+inline bool UC_IsUpper(const ovchar_t chars[], size_t index)
 {
 	bool ignore;
 	return UC_IsUpper(chars, index, &ignore);
 }
 
-inline bool UC_IsLower(const ovchar_t chars[], unsigned int index, bool *wasSurrogatePair)
+inline bool UC_IsLower(const ovchar_t chars[], size_t index, bool *wasSurrogatePair)
 {
 	return UC_IsCategory(chars, index, UC_LETTER_LOWERCASE, wasSurrogatePair);
 }
-inline bool UC_IsLower(const ovchar_t chars[], unsigned int index)
+inline bool UC_IsLower(const ovchar_t chars[], size_t index)
 {
 	bool ignore;
 	return UC_IsLower(chars, index, &ignore);

--- a/ovum-vm/inc/ovum_value.h
+++ b/ovum-vm/inc/ovum_value.h
@@ -6,11 +6,11 @@
 // This aggregate template class allows a String to be represented "literally",
 // in an aggregate initializer. Remember that you have to repeat the length twice.
 // And then you can safely cast LitString* to String*!
-template<int Len>
+template<size_t Len>
 class LitString
 {
 public:
-	const int32_t length;
+	const size_t length;
 	int32_t hashCode;
 	StringFlags flags;
 	ovchar_t chars[Len + 1];
@@ -80,6 +80,7 @@ public:
 	{
 		return reinterpret_cast<T*>(value->v.instance);
 	}
+
 	inline T *operator*() const
 	{
 		return reinterpret_cast<T*>(value->v.instance);

--- a/ovum-vm/src/debug/debugsymbols.h
+++ b/ovum-vm/src/debug/debugsymbols.h
@@ -46,12 +46,12 @@ namespace debug
 			return parent;
 		}
 
-		inline int32_t GetSymbolCount() const
+		inline size_t GetSymbolCount() const
 		{
 			return symbolCount;
 		}
 
-		inline DebugSymbol &GetSymbol(int32_t index) const
+		inline DebugSymbol &GetSymbol(size_t index) const
 		{
 			return symbols[index];
 		}
@@ -61,11 +61,16 @@ namespace debug
 	private:
 		OVUM_DISABLE_COPY_AND_ASSIGN(OverloadSymbols);
 
-		OverloadSymbols(MethodSymbols *parent, MethodOverload *overload, int32_t symbolCount, Box<DebugSymbol[]> symbols);
+		OverloadSymbols(
+			MethodSymbols *parent,
+			MethodOverload *overload,
+			size_t symbolCount,
+			Box<DebugSymbol[]> symbols
+		);
 
 		MethodSymbols *parent;
 		MethodOverload *overload;
-		int32_t symbolCount;
+		size_t symbolCount;
 		Box<DebugSymbol[]> symbols;
 
 		friend class DebugSymbolsReader;
@@ -79,7 +84,7 @@ namespace debug
 			return method;
 		}
 
-		OverloadSymbols *GetOverload(int32_t index) const;
+		OverloadSymbols *GetOverload(size_t index) const;
 
 	private:
 		OVUM_DISABLE_COPY_AND_ASSIGN(MethodSymbols);
@@ -88,10 +93,10 @@ namespace debug
 
 		Method *method;
 
-		int32_t overloadCount;
+		size_t overloadCount;
 		Box<Box<OverloadSymbols>[]> overloads;
 
-		void SetOverloads(int32_t count, Box<Box<OverloadSymbols>[]> overloads);
+		void SetOverloads(size_t count, Box<Box<OverloadSymbols>[]> overloads);
 
 		friend class DebugSymbolsReader;
 	};
@@ -101,9 +106,9 @@ namespace debug
 	public:
 		static void TryLoad(const PathName &moduleFile, Module *module);
 
-		inline SourceFile *GetSourceFile(int32_t index) const
+		inline SourceFile *GetSourceFile(size_t index) const
 		{
-			if (index < 0 || index >= fileCount)
+			if (index >= fileCount)
 				return nullptr;
 			return files.get() + index;
 		}
@@ -113,10 +118,10 @@ namespace debug
 
 		ModuleDebugData();
 
-		int32_t fileCount;
+		size_t fileCount;
 		Box<SourceFile[]> files;
 
-		int32_t methodSymbolCount;
+		size_t methodSymbolCount;
 		Box<Box<MethodSymbols>[]> methodSymbols;
 		
 		friend class GC;
@@ -157,7 +162,11 @@ namespace debug
 
 		void ReadSourceFiles(ModuleDebugData *data, const debug_file::SourceFileList *list);
 
-		void ReadMethodSymbols(Module *module, ModuleDebugData *data, const debug_file::DebugSymbolsHeader *header);
+		void ReadMethodSymbols(
+			Module *module,
+			ModuleDebugData *data,
+			const debug_file::DebugSymbolsHeader *header
+		);
 
 		Box<MethodSymbols> ReadSingleMethodSymbols(
 			ModuleDebugData *data,

--- a/ovum-vm/src/ee/instructions.cpp
+++ b/ovum-vm/src/ee/instructions.cpp
@@ -137,14 +137,14 @@ namespace instr
 
 	void CreateList::WriteArguments(MethodBuffer &buffer, MethodBuilder &builder) const
 	{
-		oa::LocalAndValue<int32_t> args = { target, capacity };
-		buffer.Write(args, oa::LOCAL_AND_VALUE<int32_t>::SIZE);
+		oa::LocalAndValue<size_t> args = { target, capacity };
+		buffer.Write(args, oa::LOCAL_AND_VALUE<size_t>::SIZE);
 	}
 
 	void CreateHash::WriteArguments(MethodBuffer &buffer, MethodBuilder &builder) const
 	{
-		oa::LocalAndValue<int32_t> args = { target, capacity };
-		buffer.Write(args, oa::LOCAL_AND_VALUE<int32_t>::SIZE);
+		oa::LocalAndValue<size_t> args = { target, capacity };
+		buffer.Write(args, oa::LOCAL_AND_VALUE<size_t>::SIZE);
 	}
 
 	void LoadStaticFunction::WriteArguments(MethodBuffer &buffer, MethodBuilder &builder) const
@@ -275,19 +275,19 @@ namespace instr
 
 	void Branch::WriteArguments(MethodBuffer &buffer, MethodBuilder &builder) const
 	{
-		oa::Branch args = { builder.GetNewOffset(target, this) };
+		oa::Branch args = { builder.GetJumpOffset(target.index, this) };
 		buffer.Write(args, oa::BRANCH_SIZE);
 	}
 
 	void ConditionalBranch::WriteArguments(MethodBuffer &buffer, MethodBuilder &builder) const
 	{
-		oa::ConditionalBranch args = { value, builder.GetNewOffset(target, this) };
+		oa::ConditionalBranch args = { value, builder.GetJumpOffset(target.index, this) };
 		buffer.Write(args, oa::CONDITIONAL_BRANCH_SIZE);
 	}
 
 	void BranchIfType::WriteArguments(MethodBuffer &buffer, MethodBuilder &builder) const
 	{
-		oa::BranchIfType args = { value, builder.GetNewOffset(target, this), type };
+		oa::BranchIfType args = { value, builder.GetJumpOffset(target.index, this), type };
 		buffer.Write(args, oa::BRANCH_IF_TYPE_SIZE);
 	}
 
@@ -299,9 +299,9 @@ namespace instr
 
 		// The buffer pointer should now be properly aligned for the first target,
 		// so let's just write them all out, shall we?
-		for (uint16_t i = 0; i < targetCount; i++)
+		for (size_t i = 0; i < targetCount; i++)
 		{
-			buffer.Write(builder.GetNewOffset(targets[i], this), sizeof(int32_t));
+			buffer.Write(builder.GetJumpOffset(targets[i].index, this), sizeof(int32_t));
 		}
 
 		// Make sure the buffer is properly aligned afterwards as well
@@ -310,13 +310,13 @@ namespace instr
 
 	void BranchIfReference::WriteArguments(MethodBuffer &buffer, MethodBuilder &builder) const
 	{
-		oa::ConditionalBranch args = { this->args, builder.GetNewOffset(target, this) };
+		oa::ConditionalBranch args = { this->args, builder.GetJumpOffset(target.index, this) };
 		buffer.Write(args, oa::CONDITIONAL_BRANCH_SIZE);
 	}
 
 	void BranchComparison::WriteArguments(MethodBuffer &buffer, MethodBuilder &builder) const
 	{
-		oa::ConditionalBranch args = { this->args, builder.GetNewOffset(target, this) };
+		oa::ConditionalBranch args = { this->args, builder.GetJumpOffset(target.index, this) };
 		buffer.Write(args, oa::CONDITIONAL_BRANCH_SIZE);
 	}
 

--- a/ovum-vm/src/ee/methodbuilder.h
+++ b/ovum-vm/src/ee/methodbuilder.h
@@ -18,17 +18,17 @@ namespace instr
 		MethodBuilder();
 		~MethodBuilder();
 
-		inline Instruction *operator[](int32_t index) const
+		inline Instruction *operator[](size_t index) const
 		{
 			return instructions[index].instr;
 		}
 
-		inline int32_t GetLength() const
+		inline size_t GetLength() const
 		{
-			return (int32_t)instructions.size();
+			return instructions.size();
 		}
 
-		inline int32_t GetByteSize() const
+		inline size_t GetByteSize() const
 		{
 			return lastOffset;
 		}
@@ -38,41 +38,41 @@ namespace instr
 			return hasBranches;
 		}
 
-		inline int32_t GetTypeCount() const
+		inline size_t GetTypeCount() const
 		{
 			return (int32_t)typesToInitialize.size();
 		}
 
-		inline Type *GetType(int32_t index) const
+		inline Type *GetType(size_t index) const
 		{
 			return typesToInitialize[index];
 		}
 
-		uint32_t GetOriginalOffset(int32_t index) const;
+		uint32_t GetOriginalOffset(size_t index) const;
 
-		uint32_t GetOriginalSize(int32_t index) const;
+		size_t GetOriginalSize(size_t index) const;
 
-		int32_t FindIndex(uint32_t originalOffset) const;
+		size_t FindIndex(uint32_t originalOffset) const;
 
-		int32_t GetNewOffset(int32_t index) const;
+		size_t GetNewOffset(size_t index) const;
 
-		int32_t GetNewOffset(int32_t index, const Instruction *relativeTo) const;
+		int32_t GetJumpOffset(size_t index, const Instruction *relativeTo) const;
 
-		ovlocals_t GetStackHeight(int32_t index) const;
+		ovlocals_t GetStackHeight(size_t index) const;
 
-		void SetStackHeight(int32_t index, ovlocals_t stackHeight);
+		void SetStackHeight(size_t index, ovlocals_t stackHeight);
 
-		uint32_t GetRefSignature(int32_t index) const;
+		uint32_t GetRefSignature(size_t index) const;
 
-		void SetRefSignature(int32_t index, uint32_t refSignature);
+		void SetRefSignature(size_t index, uint32_t refSignature);
 
-		bool IsMarkedForRemoval(int32_t index) const;
+		bool IsMarkedForRemoval(size_t index) const;
 
-		void MarkForRemoval(int32_t index);
+		void MarkForRemoval(size_t index);
 
-		void Append(uint32_t originalOffset, uint32_t originalSize, Instruction *instr);
+		void Append(uint32_t originalOffset, size_t originalSize, Instruction *instr);
 
-		void SetInstruction(int32_t index, Instruction *newInstr, bool deletePrev);
+		void SetInstruction(size_t index, Instruction *newInstr, bool deletePrev);
 
 		void PerformRemovals(MethodOverload *method);
 
@@ -85,13 +85,13 @@ namespace instr
 		{
 		public:
 			uint32_t originalOffset;
-			uint32_t originalSize;
+			size_t originalSize;
 			ovlocals_t stackHeight;
 			uint32_t refSignature;
 			bool removed;
 			Instruction *instr;
 
-			inline InstrDesc(uint32_t originalOffset, uint32_t originalSize, Instruction *instr) :
+			inline InstrDesc(uint32_t originalOffset, size_t originalSize, Instruction *instr) :
 				originalOffset(originalOffset),
 				originalSize(originalSize),
 				stackHeight(UNVISITED),
@@ -104,18 +104,18 @@ namespace instr
 		typedef std::vector<InstrDesc>::iterator instr_iter;
 		typedef std::vector<Type*>::iterator type_iter;
 
-		int32_t lastOffset;
+		size_t lastOffset;
 		bool hasBranches;
 		std::vector<InstrDesc> instructions;
 		std::vector<Type*> typesToInitialize;
 
-		void PerformRemovalsInternal(int32_t newIndices[], MethodOverload *method);
+		void PerformRemovalsInternal(size_t newIndices[], MethodOverload *method);
 	};
 
 	class MethodBuffer
 	{
 	public:
-		explicit MethodBuffer(int32_t size);
+		explicit MethodBuffer(size_t size);
 
 		~MethodBuffer();
 

--- a/ovum-vm/src/ee/methodinitexception.h
+++ b/ovum-vm/src/ee/methodinitexception.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "../vm.h"
+#include "../object/member.h"
+#include "../object/field.h"
 
 namespace ovum
 {
@@ -17,66 +19,196 @@ public:
 		STACK_HAS_REFS,
 		INACCESSIBLE_MEMBER,
 		FIELD_STATIC_MISMATCH,
-		UNRESOLVED_TOKEN_ID,
+		UNRESOLVED_TOKEN,
 		NO_MATCHING_OVERLOAD,
 		INACCESSIBLE_TYPE,
 		TYPE_NOT_CONSTRUCTIBLE,
 	};
+
+	inline static MethodInitException General(
+		const char *const message,
+		MethodOverload *method
+	)
+	{
+		return MethodInitException(message, method, GENERAL);
+	}
+
+	inline static MethodInitException InconsistentStack(
+		const char *const message,
+		MethodOverload *method,
+		size_t instrIndex
+	)
+	{
+		auto e = MethodInitException(message, method, INCONSISTENT_STACK);
+		e.instrIndex = instrIndex;
+		return std::move(e);
+	}
+
+	inline static MethodInitException InvalidBranchOffset(
+		const char *const message,
+		MethodOverload *method,
+		size_t instrIndex
+	)
+	{
+		auto e = MethodInitException(message, method, INVALID_BRANCH_OFFSET);
+		e.instrIndex = instrIndex;
+		return std::move(e);
+	}
+
+	inline static MethodInitException InsufficientStackHeight(
+		const char *const message,
+		MethodOverload *method,
+		size_t instrIndex
+	)
+	{
+		auto e = MethodInitException(message, method, INSUFFICIENT_STACK_HEIGHT);
+		e.instrIndex = instrIndex;
+		return std::move(e);
+	}
+
+	inline static MethodInitException StackHasRefs(
+		const char *const message,
+		MethodOverload *method,
+		size_t instrIndex
+	)
+	{
+		auto e = MethodInitException(message, method, STACK_HAS_REFS);
+		e.instrIndex = instrIndex;
+		return std::move(e);
+	}
+
+	inline static MethodInitException InaccessibleMember(
+		const char *const message,
+		MethodOverload *method,
+		Member *member
+	)
+	{
+		auto e = MethodInitException(message, method, INACCESSIBLE_MEMBER);
+		e.member = member;
+		return std::move(e);
+	}
+
+	inline static MethodInitException FieldStaticMismatch(
+		const char *const message,
+		MethodOverload *method,
+		Field *field
+	)
+	{
+		auto e = MethodInitException(message, method, FIELD_STATIC_MISMATCH);
+		e.member = field;
+		return std::move(e);
+	}
+
+	inline static MethodInitException UnresolvedToken(
+		const char *const message,
+		MethodOverload *method,
+		uint32_t token
+	)
+	{
+		auto e = MethodInitException(message, method, UNRESOLVED_TOKEN);
+		e.token = token;
+		return std::move(e);
+	}
+
+	inline static MethodInitException NoMatchingOverload(
+		const char *const message,
+		MethodOverload *method,
+		Method *methodGroup,
+		ovlocals_t argCount
+	)
+	{
+		auto e = MethodInitException(message, method, NO_MATCHING_OVERLOAD);
+		e.noOverload.methodGroup = methodGroup;
+		e.noOverload.argCount = argCount;
+		return std::move(e);
+	}
+
+	inline static MethodInitException InaccessibleType(
+		const char *const message,
+		MethodOverload *method,
+		Type *type
+	)
+	{
+		auto e = MethodInitException(message, method, INACCESSIBLE_TYPE);
+		e.type = type;
+		return std::move(e);
+	}
+
+	inline static MethodInitException TypeNotConstructible(
+		const char *const message,
+		MethodOverload *method,
+		Type *type
+	)
+	{
+		auto e = MethodInitException(message, method, TYPE_NOT_CONSTRUCTIBLE);
+		e.type = type;
+		return std::move(e);
+	}
+	
+	inline FailureKind GetFailureKind() const
+	{
+		return kind;
+	}
+
+	inline MethodOverload *GetMethod() const
+	{
+		return method;
+	}
+
+	inline size_t GetInstructionIndex() const
+	{
+		return instrIndex;
+	}
+
+	inline Member *GetMember() const
+	{
+		return member;
+	}
+
+	inline Type *GetType() const
+	{
+		return type;
+	}
+
+	inline uint32_t GetToken() const
+	{
+		return token;
+	}
+
+	inline Method *GetMethodGroup() const
+	{
+		return noOverload.methodGroup;
+	}
+
+	inline ovlocals_t GetArgumentCount() const
+	{
+		return noOverload.argCount;
+	}
 
 private:
 	FailureKind kind;
 	MethodOverload *method;
 
 	union {
-		int32_t instrIndex;
+		size_t instrIndex;
 		Member *member;
 		Type *type;
-		uint32_t tokenId;
+		uint32_t token;
 		struct {
 			Method *methodGroup;
-			uint32_t argCount;
+			ovlocals_t argCount;
 		} noOverload;
 	};
 
-public:
-	inline MethodInitException(const char *const message, MethodOverload *method) :
-		exception(message), method(method), kind(GENERAL)
+	inline MethodInitException(
+		const char *const message,
+		MethodOverload *method,
+		FailureKind kind
+	) :
+		exception(message),
+		method(method),
+		kind(kind)
 	{ }
-
-	inline MethodInitException(const char *const message, MethodOverload *method, int32_t instrIndex, FailureKind kind) :
-		exception(message), method(method), kind(kind), instrIndex(instrIndex)
-	{ }
-
-	inline MethodInitException(const char *const message, MethodOverload *method, Member *member, FailureKind kind) :
-		exception(message), method(method), kind(kind), member(member)
-	{ }
-
-	inline MethodInitException(const char *const message, MethodOverload *method, Type *type, FailureKind kind) :
-		exception(message), method(method), kind(kind), type(type)
-	{ }
-
-	inline MethodInitException(const char *const message, MethodOverload *method, uint32_t tokenId, FailureKind kind) :
-		exception(message), method(method), kind(kind), tokenId(tokenId)
-	{ }
-
-	inline MethodInitException(const char *const message, MethodOverload *method,
-		Method *methodGroup, uint32_t argCount, FailureKind kind) :
-		exception(message), method(method), kind(kind)
-	{
-		noOverload.methodGroup = methodGroup;
-		noOverload.argCount = argCount;
-	}
-
-	inline FailureKind GetFailureKind() const { return kind; }
-
-	inline MethodOverload *GetMethod() const { return method; }
-
-	inline int32_t GetInstructionIndex() const { return instrIndex; }
-	inline Member *GetMember() const { return member; }
-	inline Type *GetType() const { return type; }
-	inline uint32_t GetTokenId() const { return tokenId; }
-	inline Method *GetMethodGroup() const { return noOverload.methodGroup; }
-	inline uint32_t GetArgumentCount() const { return noOverload.argCount; }
 };
 
 } // namespace ovum

--- a/ovum-vm/src/ee/methodinitializer.h
+++ b/ovum-vm/src/ee/methodinitializer.h
@@ -9,48 +9,66 @@ namespace ovum
 
 class MethodInitializer
 {
-private:
-	VM *vm;
-	MethodOverload *method;
-
-	OVUM_DISABLE_COPY_AND_ASSIGN(MethodInitializer);
-
 public:
-	inline MethodInitializer(VM *vm) : vm(vm), method(nullptr)
+	inline MethodInitializer(VM *vm) :
+		vm(vm),
+		method(nullptr)
 	{ }
 
 	int Initialize(MethodOverload *method, Thread *const thread);
 
 private:
+	OVUM_DISABLE_COPY_AND_ASSIGN(MethodInitializer);
+
+	VM *vm;
+	MethodOverload *method;
+
 	void ReadInstructions(instr::MethodBuilder &builder);
 
 	void InitBranchOffsets(instr::MethodBuilder &builder);
+
 	void InitTryBlockOffsets(instr::MethodBuilder &builder);
+
 	void InitDebugSymbolOffsets(instr::MethodBuilder &builder);
 
 	void CalculateStackHeights(instr::MethodBuilder &builder, StackManager &stack);
+
 	void EnqueueInitialBranches(instr::MethodBuilder &builder, StackManager &stack);
-	void VerifyStackHeight(instr::MethodBuilder &builder, StackManager &stack, int32_t index);
-	void TryUpdateInputOutput(instr::MethodBuilder &builder, StackManager &stack, instr::Instruction *prev, instr::Instruction *instr, int32_t index);
-	void TryUpdateConditionalBranch(instr::MethodBuilder &builder, instr::Instruction *prev, instr::Branch *branch, int32_t index);
+
+	void VerifyStackHeight(instr::MethodBuilder &builder, StackManager &stack, size_t index);
+
+	void TryUpdateInputOutput(instr::MethodBuilder &builder, StackManager &stack, instr::Instruction *prev, instr::Instruction *instr, size_t index);
+
+	void TryUpdateConditionalBranch(instr::MethodBuilder &builder, instr::Instruction *prev, instr::Branch *branch, size_t index);
+
 	static bool IsBranchComparisonOperator(IntermediateOpcode opc);
+
 	static IntermediateOpcode GetBranchComparisonOpcode(IntermediateOpcode branchOpc, IntermediateOpcode comparisonOpc);
 
 	void WriteInitializedBody(instr::MethodBuilder &builder);
+
 	void FinalizeTryBlockOffsets(instr::MethodBuilder &builder);
+
 	void FinalizeDebugSymbolOffsets(instr::MethodBuilder &builder);
 
 	Type *TypeFromToken(uint32_t token);
+
 	String *StringFromToken(uint32_t token);
+
 	Method *MethodFromToken(uint32_t token);
+
 	MethodOverload *MethodOverloadFromToken(uint32_t token, ovlocals_t argCount);
+
 	Field *FieldFromToken(uint32_t token, bool shouldBeStatic);
+
 	void EnsureConstructible(Type *type, ovlocals_t argCount);
 };
 
 class StackManager
 {
 public:
+	static const size_t NO_BRANCH = (size_t)-1;
+
 	struct StackEntry
 	{
 		enum StackEntryFlags : uint8_t
@@ -61,8 +79,8 @@ public:
 		} flags;
 	};
 
-	inline StackManager(RefSignaturePool *refSignatures)
-		: refSignatures(refSignatures)
+	inline StackManager(RefSignaturePool *refSignatures) :
+		refSignatures(refSignatures)
 	{ }
 
 	inline virtual ~StackManager() { }
@@ -71,14 +89,14 @@ public:
 
 	// Adds a branch to the end of the queue, with stack slots copied from the current branch.
 	// All stack slots retain their flags.
-	virtual void EnqueueBranch(int32_t firstInstr) = 0;
+	virtual void EnqueueBranch(size_t firstInstr) = 0;
 	// Adds a branch to the end of the queue, with the specified initial stack height.
 	// The stack slots in the new branch have no special flags.
-	virtual void EnqueueBranch(ovlocals_t stackHeight, int32_t firstInstr) = 0;
+	virtual void EnqueueBranch(ovlocals_t stackHeight, size_t firstInstr) = 0;
 
 	// Moves to the next branch in the queue, and returns
 	// the index of the first instruction in the branch.
-	virtual int32_t DequeueBranch() = 0;
+	virtual size_t DequeueBranch() = 0;
 
 	virtual bool ApplyStackChange(instr::StackChange change, bool pushRef) = 0;
 

--- a/ovum-vm/src/ee/refsignature.cpp
+++ b/ovum-vm/src/ee/refsignature.cpp
@@ -35,12 +35,12 @@ bool RefSignature::IsParamRef(ovlocals_t index) const
 
 LongRefSignature::LongRefSignature(ovlocals_t paramCount)
 {
-	uint32_t maskCount = (paramCount + ParamsPerMask - 1) / ParamsPerMask;
+	ovlocals_t maskCount = (paramCount + ParamsPerMask - 1) / ParamsPerMask;
 
 	this->paramCount = maskCount * ParamsPerMask;
 
 	maskValues = Box<uint32_t[]>(new uint32_t[maskCount]);
-	for (uint32_t i = 0; i < maskCount; i++)
+	for (ovlocals_t i = 0; i < maskCount; i++)
 		maskValues[i] = 0;
 }
 
@@ -82,8 +82,8 @@ bool LongRefSignature::Equals(const LongRefSignature &other) const
 
 uint32_t RefSignaturePool::Add(LongRefSignature *signature, bool &isNew)
 {
-	uint32_t i = 0;
-	while (i < (uint32_t)signatures.size())
+	size_t i = 0;
+	while (i < signatures.size())
 	{
 		auto &item = signatures[i];
 		if (item->Equals(*signature))

--- a/ovum-vm/src/ee/refsignature.h
+++ b/ovum-vm/src/ee/refsignature.h
@@ -114,7 +114,7 @@ private:
 	ovlocals_t paramCount;
 	Box<uint32_t[]> maskValues;
 
-	static const uint32_t ParamsPerMask = 32;
+	static const ovlocals_t ParamsPerMask = 32;
 
 	friend class RefSignature;
 };

--- a/ovum-vm/src/ee/stacktraceformatter.cpp
+++ b/ovum-vm/src/ee/stacktraceformatter.cpp
@@ -214,7 +214,7 @@ void StackTraceFormatter::AppendSourceLocation(Thread *const thread, StringBuffe
 void StackTraceFormatter::AppendLineNumber(Thread *const thread, StringBuffer &buf, int32_t line)
 {
 	// 32 digits ought to be enough for anybody
-	const ovchar_t BUFFER_SIZE = 32;
+	const size_t BUFFER_SIZE = 32;
 
 	ovchar_t lineNumberStr[BUFFER_SIZE];
 	ovchar_t *chp = lineNumberStr + BUFFER_SIZE;

--- a/ovum-vm/src/ee/stacktraceformatter.h
+++ b/ovum-vm/src/ee/stacktraceformatter.h
@@ -45,7 +45,7 @@ private:
 
 	static void AppendLineNumber(Thread *const thread, StringBuffer &buf, int32_t line);
 
-	static const int32_t STRING_BUFFER_CAPACITY = 1024;
+	static const size_t STRING_BUFFER_CAPACITY = 1024;
 };
 
 } // namespace ovum

--- a/ovum-vm/src/ee/thread.h
+++ b/ovum-vm/src/ee/thread.h
@@ -525,6 +525,8 @@ private:
 	// The currently executing managed thread.
 	static TlsEntry<Thread> threadKey;
 
+	static const size_t ALL_TRY_BLOCKS = (size_t)-1;
+
 	// The current instruction pointer. This should always be the first field in
 	// the class.
 	uint8_t *ip;
@@ -688,8 +690,8 @@ private:
 	// considered to be inside the try block. Hence, that block's catch clauses
 	// will not be found, nor will its finally block be executed.
 	//   maxIndex:
-	//     The maximum try block index to look at, exclusive. Pass -1 to examine
-	//     all try blocks in the method.
+	//     The maximum try block index to look at, exclusive. To examine all try
+	//     blocks in the method, pass ALL_TRY_BLOCKS.
 	//
 	//     Try blocks are stored inside out (most deeply nested try blocks first,
 	//     followed by their parents). When an error is thrown inside a finally
@@ -700,7 +702,7 @@ private:
 	//   Catch, finally and fault clauses can cause errors to be thrown. This
 	//   method returns OVUM_SUCCESS if an error handler was successfully found
 	//   and executed.
-	int FindErrorHandler(int32_t maxIndex);
+	int FindErrorHandler(size_t maxIndex);
 
 	// Attempts to evaluate a 'leave' instruction. This will execute any finally
 	// and fault clauses that lie between the 'leave' instruction and the specified

--- a/ovum-vm/src/ee/thread.methodinitializer.cpp
+++ b/ovum-vm/src/ee/thread.methodinitializer.cpp
@@ -17,7 +17,7 @@ int Thread::InitializeMethod(MethodOverload *method)
 
 int Thread::CallStaticConstructors(instr::MethodBuilder &builder)
 {
-	for (int32_t i = 0; i < builder.GetTypeCount(); i++)
+	for (size_t i = 0; i < builder.GetTypeCount(); i++)
 	{
 		Type *type = builder.GetType(i);
 		// The static constructor may have been triggered by a previous type initialization,

--- a/ovum-vm/src/ee/vm.h
+++ b/ovum-vm/src/ee/vm.h
@@ -23,7 +23,7 @@ private:
 	Box<Thread> mainThread;
 
 	// Number of command-line arguments.
-	int argCount;
+	size_t argCount;
 	// Command-line argument values. Each Value* is a pointer into
 	// a StaticRef.
 	Box<Value*[]> argValues;
@@ -58,7 +58,9 @@ private:
 	Box<StaticStrings> strings;
 
 	int LoadModules(VMStartParams &params);
-	int InitArgs(int argCount, const wchar_t *args[]);
+
+	int InitArgs(size_t argCount, const wchar_t *args[]);
+
 	int GetMainMethodOverload(Method *method, ovlocals_t &argc, MethodOverload *&overload);
 
 	static void PrintInternal(FILE *file, const wchar_t *format, String *str);
@@ -115,18 +117,28 @@ public:
 	}
 
 	static void Print(String *str);
+
 	static void Printf(const wchar_t *format, String *str);
+
 	static void PrintLn(String *str);
 
 	static void PrintErr(String *str);
+
 	static void PrintfErr(const wchar_t *format, String *str);
+
 	static void PrintErrLn(String *str);
 
-	inline int GetArgCount() { return argCount; }
-	int GetArgs(int destLength, String *dest[]);
-	int GetArgValues(int destLength, Value dest[]);
+	inline size_t GetArgCount()
+	{
+		return argCount;
+	}
+
+	size_t GetArgs(size_t destLength, String *dest[]);
+
+	size_t GetArgValues(size_t destLength, Value dest[]);
 
 	void PrintUnhandledError(Thread *const thread);
+
 	void PrintMethodInitException(MethodInitException &e);
 
 	// Contains the VM running on the current thread.

--- a/ovum-vm/src/gc/gc.cpp
+++ b/ovum-vm/src/gc/gc.cpp
@@ -237,7 +237,7 @@ int GC::Alloc(Thread *const thread, Type *type, size_t size, Value *output)
 	return r;
 }
 
-int GC::AllocArray(Thread *const thread, uint32_t length, size_t itemSize, void **output)
+int GC::AllocArray(Thread *const thread, size_t length, size_t itemSize, void **output)
 {
 	if (itemSize > 0 && length > SIZE_MAX / itemSize)
 		return thread->ThrowOverflowError();
@@ -252,7 +252,7 @@ int GC::AllocArray(Thread *const thread, uint32_t length, size_t itemSize, void 
 	RETURN_SUCCESS;
 }
 
-int GC::AllocValueArray(Thread *const thread, uint32_t length, Value **output)
+int GC::AllocValueArray(Thread *const thread, size_t length, Value **output)
 {
 	if (length > SIZE_MAX / sizeof(Value))
 		return thread->ThrowOverflowError();
@@ -363,7 +363,7 @@ int GC::ConstructLL(Thread *const thread, Type *type, ovlocals_t argc, Value *ar
 	}
 }
 
-String *GC::ConstructString(Thread *const thread, int32_t length, const ovchar_t value[])
+String *GC::ConstructString(Thread *const thread, size_t length, const ovchar_t value[])
 {
 	GCObject *gco;
 	// Note: sizeof(String) includes firstChar, but we need an extra character
@@ -391,7 +391,7 @@ String *GC::ConvertString(Thread *const thread, const char *string)
 	if (length > INT32_MAX)
 		return nullptr;
 
-	String *output = ConstructString(thread, (int32_t)length, nullptr);
+	String *output = ConstructString(thread, length, nullptr);
 
 	if (output && length > 0)
 	{
@@ -403,7 +403,7 @@ String *GC::ConvertString(Thread *const thread, const char *string)
 	return output;
 }
 
-String *GC::ConstructModuleString(Thread *const thread, int32_t length, const ovchar_t value[])
+String *GC::ConstructModuleString(Thread *const thread, size_t length, const ovchar_t value[])
 {
 	// Replicate some functionality of Alloc here
 	size_t size = sizeof(String) + length*sizeof(ovchar_t) + GCO_SIZE;
@@ -778,7 +778,7 @@ OVUM_API int GC_Construct(ThreadHandle thread, TypeHandle type, ovlocals_t argc,
 	return thread->GetGC()->Construct(thread, type, argc, output);
 }
 
-OVUM_API String *GC_ConstructString(ThreadHandle thread, int32_t length, const ovchar_t *values)
+OVUM_API String *GC_ConstructString(ThreadHandle thread, size_t length, const ovchar_t *values)
 {
 	return thread->GetGC()->ConstructString(thread, length, values);
 }
@@ -788,12 +788,12 @@ OVUM_API int GC_Alloc(ThreadHandle thread, TypeHandle type, size_t size, Value *
 	return thread->GetGC()->Alloc(thread, type, size, output);
 }
 
-OVUM_API int GC_AllocArray(ThreadHandle thread, uint32_t length, size_t itemSize, void **output)
+OVUM_API int GC_AllocArray(ThreadHandle thread, size_t length, size_t itemSize, void **output)
 {
 	return thread->GetGC()->AllocArray(thread, length, itemSize, output);
 }
 
-OVUM_API int GC_AllocValueArray(ThreadHandle thread, uint32_t length, Value **output)
+OVUM_API int GC_AllocValueArray(ThreadHandle thread, size_t length, Value **output)
 {
 	return thread->GetGC()->AllocValueArray(thread, length, output);
 }

--- a/ovum-vm/src/gc/gc.h
+++ b/ovum-vm/src/gc/gc.h
@@ -17,7 +17,7 @@ namespace ovum
 // IF STRING CHANGES, MUTABLESTRING MUST BE UPDATED TO REFLECT THAT.
 struct MutableString
 {
-	uint32_t length;
+	size_t length;
 	uint32_t hashCode;
 	StringFlags flags;
 	ovchar_t firstChar;
@@ -49,15 +49,15 @@ public:
 	int Alloc(Thread *const thread, Type *type, size_t size, GCObject **output);
 	int Alloc(Thread *const thread, Type *type, size_t size, Value *output);
 
-	int AllocArray(Thread *const thread, uint32_t length, uint32_t itemSize, void **output);
+	int AllocArray(Thread *const thread, size_t length, size_t itemSize, void **output);
 
-	int AllocValueArray(Thread *const thread, uint32_t length, Value **output);
+	int AllocValueArray(Thread *const thread, size_t length, Value **output);
 
-	String *ConstructString(Thread *const thread, int32_t length, const ovchar_t value[]);
+	String *ConstructString(Thread *const thread, size_t length, const ovchar_t value[]);
 
 	String *ConvertString(Thread *const thread, const char *string);
 
-	String *ConstructModuleString(Thread *const thread, int32_t length, const ovchar_t value[]);
+	String *ConstructModuleString(Thread *const thread, size_t length, const ovchar_t value[]);
 
 	String *GetInternedString(Thread *const thread, String *value);
 

--- a/ovum-vm/src/gc/gcobject.h
+++ b/ovum-vm/src/gc/gcobject.h
@@ -124,6 +124,7 @@ public:
 
 	uint8_t *InstanceBase();
 	uint8_t *InstanceBase(Type *type);
+
 	Value *FieldsBase();
 	Value *FieldsBase(Type *type);
 
@@ -187,6 +188,7 @@ public:
 	}
 
 	static GCObject *FromInst(void *inst);
+
 	static GCObject *FromValue(Value *value);
 };
 

--- a/ovum-vm/src/gc/objectgraphwalker.h
+++ b/ovum-vm/src/gc/objectgraphwalker.h
@@ -86,13 +86,13 @@ public:
 private:
 	static void VisitFields(ObjectGraphVisitor &visitor, GCObject *gco);
 
-	static void VisitValueArray(ObjectGraphVisitor &visitor, uint32_t count, Value *values);
+	static void VisitValueArray(ObjectGraphVisitor &visitor, size_t count, Value *values);
 
 	static void VisitCustomFields(ObjectGraphVisitor &visitor, Type *type, void *instanceBase);
 
 	static void VisitNativeFields(ObjectGraphVisitor &visitor, Type *type, void *instanceBase);
 
-	static int OVUM_CDECL ReferenceVisitorCallback(void *state, unsigned int count, Value *values);
+	static int OVUM_CDECL ReferenceVisitorCallback(void *state, size_t count, Value *values);
 };
 
 } // namespace ovum

--- a/ovum-vm/src/gc/rootsetwalker.cpp
+++ b/ovum-vm/src/gc/rootsetwalker.cpp
@@ -88,8 +88,8 @@ void RootSetWalker::VisitModule(RootSetVisitor &visitor, Module *module)
 {
 	visitor.VisitRootString(module->GetName());
 
-	int32_t stringCount = module->strings.GetLength();
-	for (int32_t i = 0; i < stringCount; i++)
+	size_t stringCount = module->strings.GetLength();
+	for (size_t i = 0; i < stringCount; i++)
 		visitor.VisitRootString(module->strings[i]);
 
 	if (module->debugData)
@@ -98,8 +98,8 @@ void RootSetWalker::VisitModule(RootSetVisitor &visitor, Module *module)
 
 void RootSetWalker::VisitDebugData(RootSetVisitor &visitor, debug::ModuleDebugData *debug)
 {
-	int32_t fileCount = debug->fileCount;
-	for (int32_t i = 0; i < fileCount; i++)
+	size_t fileCount = debug->fileCount;
+	for (size_t i = 0; i < fileCount; i++)
 		visitor.VisitRootString(debug->files[i].fileName);
 }
 
@@ -109,8 +109,8 @@ void RootSetWalker::VisitStaticRefs(RootSetVisitor &visitor, StaticRefBlock *ref
 	{
 		if (visitor.EnterStaticRefBlock(refs))
 		{
-			uint32_t count = refs->count;
-			for (uint32_t i = 0; i < count; i++)
+			size_t count = refs->count;
+			for (size_t i = 0; i < count; i++)
 				visitor.VisitRootValue(refs->values[i].GetValuePointer());
 			visitor.LeaveStaticRefBlock(refs);
 		}

--- a/ovum-vm/src/gc/staticref.h
+++ b/ovum-vm/src/gc/staticref.h
@@ -70,7 +70,7 @@ private:
 	bool hasGen0Refs;
 
 	// Number of used slots
-	uint32_t count;
+	size_t count;
 	StaticRef values[BLOCK_SIZE];
 
 	inline StaticRefBlock() :

--- a/ovum-vm/src/gc/stringtable.h
+++ b/ovum-vm/src/gc/stringtable.h
@@ -12,28 +12,8 @@ namespace ovum
 // Strings can also be explicitly interned.
 class StringTable
 {
-private:
-	struct Entry
-	{
-		int32_t next;     // index of the next entry in the bucket; -1 if unused
-		int32_t hashCode; // The lower 31 bits of the hash code
-		String *value;    // the actual string!
-	};
-
-	int32_t capacity;   // size of buckets and entries
-	int32_t count;      // total number of entries used
-	int32_t freeCount;  // total number of freed entries
-	int32_t freeList;   // index of first freed entry
-	int32_t *buckets;   // indexes into entries
-	Entry *entries; // the actual entries
-
-	String *GetValue(String *value, const bool add);
-
-	void Resize();
-
 public:
-	StringTable(const int32_t capacity);
-	~StringTable();
+	StringTable(size_t capacity);
 
 	String *GetInterned(String *value);
 
@@ -47,6 +27,37 @@ public:
 	bool RemoveIntern(String *value);
 
 	void UpdateIntern(String *value);
+
+private:
+	static const size_t LAST = (size_t)-1;
+
+	struct Entry
+	{
+		// Index of the next entry in the bucket. If there is no next
+		// entry, the value is LAST.
+		size_t next;
+		// The lower 31 bits of the hash code.
+		int32_t hashCode;
+		// The actual string!
+		String *value;
+	};
+
+	// Size of buckets and entries.
+	size_t capacity;
+	// Total number of entries used.
+	size_t count;
+	// Total number of entries that were freed after being used.
+	size_t freeCount;
+	// Index of first freed entry.
+	size_t freeList;
+	// Indexes into entries.
+	Box<size_t[]> buckets;
+	// The actual entries.
+	Box<Entry[]> entries;
+
+	String *GetValue(String *value, bool add);
+
+	void Resize();
 
 	friend class GC;
 };

--- a/ovum-vm/src/module/globalmember.cpp
+++ b/ovum-vm/src/module/globalmember.cpp
@@ -5,7 +5,7 @@
 namespace ovum
 {
 
-GlobalMember &&GlobalMember::FromType(Type *type)
+GlobalMember GlobalMember::FromType(Type *type)
 {
 	GlobalMember result(
 		GlobalMemberFlags::TYPE,
@@ -16,7 +16,7 @@ GlobalMember &&GlobalMember::FromType(Type *type)
 	return std::move(result);
 }
 
-GlobalMember &&GlobalMember::FromFunction(Method *function)
+GlobalMember GlobalMember::FromFunction(Method *function)
 {
 	GlobalMember result(
 		GlobalMemberFlags::FUNCTION,
@@ -27,7 +27,7 @@ GlobalMember &&GlobalMember::FromFunction(Method *function)
 	return std::move(result);
 }
 
-GlobalMember &&GlobalMember::FromConstant(String *name, Value *value, bool isInternal)
+GlobalMember GlobalMember::FromConstant(String *name, Value *value, bool isInternal)
 {
 	GlobalMember result(
 		GlobalMemberFlags::CONSTANT,

--- a/ovum-vm/src/module/globalmember.h
+++ b/ovum-vm/src/module/globalmember.h
@@ -93,11 +93,11 @@ public:
 
 	void ToPublicGlobalMember(::GlobalMember *result) const;
 
-	static GlobalMember &&FromType(Type *type);
+	static GlobalMember FromType(Type *type);
 
-	static GlobalMember &&FromFunction(Method *function);
+	static GlobalMember FromFunction(Method *function);
 
-	static GlobalMember &&FromConstant(String *name, Value *value, bool isInternal);
+	static GlobalMember FromConstant(String *name, Value *value, bool isInternal);
 
 private:
 	GlobalMemberFlags flags;

--- a/ovum-vm/src/module/membertable.h
+++ b/ovum-vm/src/module/membertable.h
@@ -12,9 +12,9 @@ class MemberTableBase
 {
 public:
 	// The total number of slots
-	int32_t capacity;
+	size_t capacity;
 	// The total number of entries (that is, number of used slots).
-	int32_t length;
+	size_t length;
 	Box<T[]> entries;
 
 	inline MemberTableBase() :
@@ -23,7 +23,7 @@ public:
 		entries(nullptr)
 	{ }
 
-	inline void Init(int32_t capacity)
+	inline void Init(size_t capacity)
 	{
 		// Init should only be called with a non-zero capacity once
 		OVUM_ASSERT(this->capacity == 0);
@@ -35,7 +35,7 @@ public:
 			this->entries = nullptr;
 	}
 
-	inline bool HasItem(int32_t index) const
+	inline bool HasItem(size_t index) const
 	{
 		return index >= 0 && index < length;
 	}
@@ -45,7 +45,7 @@ template<class T>
 class MemberTable : private MemberTableBase<T>
 {
 public:
-	inline MemberTable(int32_t capacity) :
+	inline explicit MemberTable(size_t capacity) :
 		MemberTableBase()
 	{
 		Init(capacity);
@@ -54,23 +54,23 @@ public:
 		MemberTableBase()
 	{ }
 
-	inline T &operator[](int32_t index) const
+	inline T &operator[](size_t index) const
 	{
 		return entries[index];
 	}
 
-	inline int32_t GetLength() const
+	inline size_t GetLength() const
 	{
 		return length;
 	}
 
-	inline int32_t GetCapacity() const
+	inline size_t GetCapacity() const
 	{
 		return capacity;
 	}
 
 private:
-	inline void Init(int32_t capacity)
+	inline void Init(size_t capacity)
 	{
 		this->MemberTableBase::Init(capacity);
 	}
@@ -89,7 +89,7 @@ template<class T>
 class MemberTable<T*> : private MemberTableBase<T*>
 {
 public:
-	inline MemberTable(int32_t capacity) :
+	inline explicit MemberTable(size_t capacity) :
 		MemberTableBase()
 	{
 		Init(capacity);
@@ -98,25 +98,25 @@ public:
 		MemberTableBase()
 	{ }
 
-	inline T *operator[](int32_t index) const
+	inline T *operator[](size_t index) const
 	{
 		if (!HasItem(index))
 			return nullptr;
 		return entries[index];
 	}
 
-	inline int32_t GetLength() const
+	inline size_t GetLength() const
 	{
 		return length;
 	}
 
-	inline int32_t GetCapacity() const
+	inline size_t GetCapacity() const
 	{
 		return capacity;
 	}
 
 private:
-	inline void Init(int32_t capacity)
+	inline void Init(size_t capacity)
 	{
 		this->MemberTableBase::Init(capacity);
 	}

--- a/ovum-vm/src/module/module.cpp
+++ b/ovum-vm/src/module/module.cpp
@@ -58,7 +58,7 @@ Module::~Module()
 
 Module *Module::FindModuleRef(String *name) const
 {
-	for (int32_t i = 0; i < moduleRefs.GetLength(); i++)
+	for (size_t i = 0; i < moduleRefs.GetLength(); i++)
 		if (String_Equals(moduleRefs[i]->name, name))
 			return moduleRefs[i];
 
@@ -402,12 +402,12 @@ OVUM_API bool Module_GetGlobalMember(ModuleHandle module, String *name, bool inc
 	return false;
 }
 
-OVUM_API int32_t Module_GetGlobalMemberCount(ModuleHandle module)
+OVUM_API size_t Module_GetGlobalMemberCount(ModuleHandle module)
 {
 	return module->GetMemberCount();
 }
 
-OVUM_API bool Module_GetGlobalMemberByIndex(ModuleHandle module, int32_t index, GlobalMember *result)
+OVUM_API bool Module_GetGlobalMemberByIndex(ModuleHandle module, size_t index, GlobalMember *result)
 {
 	ovum::GlobalMember member;
 	if (module->GetMemberByIndex(index, member))
@@ -443,9 +443,9 @@ OVUM_API ModuleHandle Module_FindDependency(ModuleHandle module, String *name)
 	return module->FindModuleRef(name);
 }
 
-OVUM_API int Module_GetSearchDirectories(ThreadHandle thread, int resultSize, String **result, int *count)
+OVUM_API int Module_GetSearchDirectories(ThreadHandle thread, size_t resultSize, String **result, size_t *count)
 {
-	const int BUFFER_SIZE = 16;
+	const size_t BUFFER_SIZE = 16;
 
 	ovum::VM *vm = thread->GetVM();
 	ovum::ModuleFinder finder(vm);
@@ -454,10 +454,10 @@ OVUM_API int Module_GetSearchDirectories(ThreadHandle thread, int resultSize, St
 	// need to fetch them into an intermediate container in order
 	// to convert them to String*s.
 	const ovum::PathName *paths[BUFFER_SIZE];
-	int dirCount = finder.GetSearchDirectories(BUFFER_SIZE, paths);
+	size_t dirCount = finder.GetSearchDirectories(BUFFER_SIZE, paths);
 
 	resultSize = min(resultSize, dirCount);
-	for (int i = 0; i < resultSize; i++)
+	for (size_t i = 0; i < resultSize; i++)
 	{
 		String *name = paths[i]->ToManagedString(thread);
 		if (name == nullptr)

--- a/ovum-vm/src/module/module.h
+++ b/ovum-vm/src/module/module.h
@@ -19,7 +19,7 @@ struct ModuleParams
 	String *name; // The name of the module
 	ModuleVersion version;
 	// Type count + function count + constant count
-	int32_t globalMemberCount;
+	size_t globalMemberCount;
 };
 
 // And then the actual Module class! Hurrah!
@@ -44,12 +44,12 @@ public:
 		return fileName;
 	}
 
-	inline int32_t GetMemberCount() const
+	inline size_t GetMemberCount() const
 	{
 		return members.GetCount();
 	}
 
-	inline bool GetMemberByIndex(int32_t index, GlobalMember &result) const
+	inline bool GetMemberByIndex(size_t index, GlobalMember &result) const
 	{
 		return members.GetByIndex(index, result);
 	}

--- a/ovum-vm/src/module/modulefinder.cpp
+++ b/ovum-vm/src/module/modulefinder.cpp
@@ -22,11 +22,11 @@ void ModuleFinder::InitSearchDirectories()
 	*searchDirs++ = vm->GetModulePath();
 }
 
-int ModuleFinder::GetSearchDirectories(int resultSize, const PathName **result) const
+size_t ModuleFinder::GetSearchDirectories(size_t resultSize, const PathName **result) const
 {
-	int count = min(resultSize, SEARCH_DIR_COUNT);
+	size_t count = min(resultSize, SEARCH_DIR_COUNT);
 
-	CopyMemoryT(result, searchDirs, (size_t)resultSize);
+	CopyMemoryT(result, searchDirs, resultSize);
 
 	return SEARCH_DIR_COUNT;
 }
@@ -40,7 +40,7 @@ bool ModuleFinder::FindModulePath(String *module, ModuleVersion *version, PathNa
 	PathName modulePath(MODULE_PATH_CAPACITY);
 
 	bool found = false;
-	for (int i = 0; i < SEARCH_DIR_COUNT; i++)
+	for (size_t i = 0; i < SEARCH_DIR_COUNT; i++)
 	{
 		found = SearchDirectory(searchDirs[i], module, versionNumber, modulePath);
 		if (found)
@@ -55,7 +55,7 @@ bool ModuleFinder::FindModulePath(String *module, ModuleVersion *version, PathNa
 bool ModuleFinder::SearchDirectory(const PathName *dir, String *module, const PathName &version, PathName &result) const
 {
 	result.ReplaceWith(*dir);
-	uint32_t simpleName = result.Join(module);
+	size_t simpleName = result.Join(module);
 	// Versioned names first:
 	//    dir/$name-$version/$name.ovm
 	//    dir/$name-$version.ovm
@@ -63,7 +63,7 @@ bool ModuleFinder::SearchDirectory(const PathName *dir, String *module, const Pa
 	{
 		result.Append(VERSION_SEPARATOR);
 		// The length for dir/$name-$version
-		uint32_t versionedName = result.Append(version);
+		size_t versionedName = result.Append(version);
 
 		// dir/$name-version/$name.ovm
 		result.Join(module);
@@ -101,9 +101,9 @@ bool ModuleFinder::SearchDirectory(const PathName *dir, String *module, const Pa
 
 void ModuleFinder::AppendVersionString(PathName &dest, ModuleVersion *version) const
 {
-	static const int32_t BUFFER_SIZE = 16;
+	static const size_t BUFFER_SIZE = 16;
 	ovchar_t buffer[BUFFER_SIZE];
-	int32_t length;
+	size_t length;
 
 	length = IntFormatter::ToDec(version->major, buffer, BUFFER_SIZE);
 	dest.Append(length, buffer);

--- a/ovum-vm/src/module/modulefinder.h
+++ b/ovum-vm/src/module/modulefinder.h
@@ -35,7 +35,7 @@ namespace ovum
 class ModuleFinder
 {
 private:
-	static const int SEARCH_DIR_COUNT = 3;
+	static const size_t SEARCH_DIR_COUNT = 3;
 
 	VM *vm;
 	const PathName *searchDirs[SEARCH_DIR_COUNT];
@@ -46,7 +46,7 @@ public:
 	// Gets the total number of directories that will be searched for modules.
 	// The module finder tries several paths within each directory; see the
 	// class documentation.
-	inline int GetSearchDirectoryCount() const
+	inline size_t GetSearchDirectoryCount() const
 	{
 		return SEARCH_DIR_COUNT;
 	}
@@ -67,7 +67,7 @@ public:
 	// Returns:
 	//   The total number of search directories. If the buffer is too small, the
 	//   return value will be larger than resultSize.
-	int GetSearchDirectories(int resultSize, const PathName **result) const;
+	size_t GetSearchDirectories(size_t resultSize, const PathName **result) const;
 
 	bool FindModulePath(String *module, ModuleVersion *version, PathName &result) const;
 
@@ -78,8 +78,8 @@ private:
 
 	void AppendVersionString(PathName &dest, ModuleVersion *version) const;
 
-	static const uint32_t MODULE_PATH_CAPACITY = 256;
-	static const uint32_t VERSION_NUMBER_CAPACITY = 32;
+	static const size_t MODULE_PATH_CAPACITY = 256;
+	static const size_t VERSION_NUMBER_CAPACITY = 32;
 	// File extension for module files; currently ".ovm"
 	static const pathchar_t *const EXTENSION;
 	// Separator between module name and version number; currently "-"

--- a/ovum-vm/src/module/modulepool.cpp
+++ b/ovum-vm/src/module/modulepool.cpp
@@ -5,13 +5,13 @@
 namespace ovum
 {
 
-Box<ModulePool> ModulePool::New(int capacity)
+Box<ModulePool> ModulePool::New(size_t capacity)
 {
 	Box<ModulePool> pool(new ModulePool(capacity));
 	return std::move(pool);
 }
 
-ModulePool::ModulePool(int capacity) :
+ModulePool::ModulePool(size_t capacity) :
 	capacity(0),
 	length(0),
 	data(nullptr)
@@ -19,7 +19,7 @@ ModulePool::ModulePool(int capacity) :
 	Init(capacity);
 }
 
-void ModulePool::Init(int capacity)
+void ModulePool::Init(size_t capacity)
 {
 	capacity = max(capacity, 4);
 
@@ -30,14 +30,14 @@ void ModulePool::Init(int capacity)
 
 Module *ModulePool::Get(String *name) const
 {
-	for (int i = 0; i < length; i++)
+	for (size_t i = 0; i < length; i++)
 		if (String_Equals(data[i]->name, name))
 			return data[i].get();
 	return nullptr;
 }
 Module *ModulePool::Get(String *name, ModuleVersion *version) const
 {
-	for (int i = 0; i < length; i++)
+	for (size_t i = 0; i < length; i++)
 	{
 		Module *module = data[i].get();
 		if (String_Equals(module->name, name) && module->version == *version)
@@ -46,12 +46,12 @@ Module *ModulePool::Get(String *name, ModuleVersion *version) const
 	return nullptr;
 }
 
-int ModulePool::Add(Box<Module> value)
+size_t ModulePool::Add(Box<Module> value)
 {
 	if (length == capacity)
 		Resize();
 
-	int index = length++;
+	size_t index = length++;
 	data[index] = std::move(value);
 	return index;
 }
@@ -59,7 +59,7 @@ int ModulePool::Add(Box<Module> value)
 Box<Module> ModulePool::Remove(Module *value)
 {
 	Box<Module> foundModule;
-	for (int i = 0; i < length; i++)
+	for (size_t i = 0; i < length; i++)
 	{
 		if (foundModule)
 			data[i - 1] = std::move(data[i]);
@@ -73,10 +73,10 @@ Box<Module> ModulePool::Remove(Module *value)
 
 void ModulePool::Resize()
 {
-	int newCap = capacity * 2;
+	size_t newCap = capacity * 2;
 
 	Box<Box<Module>[]> newData = Box<Box<Module>[]>(new Box<Module>[newCap]);
-	for (int i = 0; i < length; i++)
+	for (size_t i = 0; i < length; i++)
 		newData[i] = std::move(data[i]);
 
 	capacity = newCap;

--- a/ovum-vm/src/module/modulepool.h
+++ b/ovum-vm/src/module/modulepool.h
@@ -10,9 +10,9 @@ namespace ovum
 class ModulePool
 {
 public:
-	static Box<ModulePool> New(int capacity);
+	static Box<ModulePool> New(size_t capacity);
 
-	inline int GetLength() const
+	inline size_t GetLength() const
 	{
 		return length;
 	}
@@ -24,25 +24,25 @@ public:
 	Module *Get(String *name) const;
 	Module *Get(String *name, ModuleVersion *version) const;
 
-	inline void Set(int index, Box<Module> value)
+	inline void Set(size_t index, Box<Module> value)
 	{
 		data[index] = std::move(value);
 	}
 
-	int Add(Box<Module> value);
+	size_t Add(Box<Module> value);
 
 	Box<Module> Remove(Module *value);
 
 private:
 	OVUM_DISABLE_COPY_AND_ASSIGN(ModulePool);
 
-	int capacity;
-	int length;
+	size_t capacity;
+	size_t length;
 	Box<Box<Module>[]> data;
 
-	ModulePool(int capacity);
+	explicit ModulePool(size_t capacity);
 
-	void Init(int capacity);
+	void Init(size_t capacity);
 
 	void Resize();
 };

--- a/ovum-vm/src/module/modulereader.h
+++ b/ovum-vm/src/module/modulereader.h
@@ -158,21 +158,21 @@ private:
 
 	void RunTypeIniter(Module *module, Type *type, module_file::Rva<module_file::ByteString> initerRva);
 
-	void ReadFieldDefs(Module *module, Type *type, uint32_t fieldsBase, int32_t count, Token firstField);
+	void ReadFieldDefs(Module *module, Type *type, uint32_t fieldsBase, size_t count, Token firstField);
 
 	void ReadFieldConstantValue(Module *module, Field *field, const module_file::ConstantValue *value, bool allowUnresolvedType);
 
 	void AddUnresolvedConstant(Module *module, Field *field, const module_file::ConstantValue *value);
 
-	void ReadMethodDefs(Module *module, Type *type, uint32_t methodsBase, int32_t count, Token firstMethod);
+	void ReadMethodDefs(Module *module, Type *type, uint32_t methodsBase, size_t count, Token firstMethod);
 
 	Method *FindBaseMethod(Method *method, Type *declType);
 
-	void ReadPropertyDefs(Module *module, Type *type, int32_t count, module_file::Rva<module_file::PropertyDef[]> properties);
+	void ReadPropertyDefs(Module *module, Type *type, size_t count, module_file::Rva<module_file::PropertyDef[]> properties);
 
 	Method *ReadPropertyAccessor(Module *module, Type *type, Token token, MemberFlags &flags);
 
-	void ReadOperatorDefs(Module *module, Type *type, int32_t count, module_file::Rva<module_file::OperatorDef[]> operators);
+	void ReadOperatorDefs(Module *module, Type *type, size_t count, module_file::Rva<module_file::OperatorDef[]> operators);
 
 	void ResolveRemainingConstants(Module *module);
 
@@ -184,7 +184,7 @@ private:
 
 	Box<Method> ReadSingleMethodDef(Module *module, const module_file::MethodDef *def);
 
-	void ReadParameters(Module *module, MethodOverload *overload, int32_t count, module_file::Rva<module_file::Parameter[]> rva);
+	void ReadParameters(Module *module, MethodOverload *overload, size_t count, module_file::Rva<module_file::Parameter[]> rva);
 
 	void ReadMethodBody(Module *module, MethodOverload *overload, const module_file::OverloadDef *def);
 
@@ -194,7 +194,7 @@ private:
 
 	void ReadLongMethodBody(Module *module, MethodOverload *overload, const module_file::MethodHeader *header);
 
-	void ReadTryBlocks(Module *module, MethodOverload *overload, int32_t count, module_file::Rva<module_file::TryBlock[]> rva);
+	void ReadTryBlocks(Module *module, MethodOverload *overload, size_t count, module_file::Rva<module_file::TryBlock[]> rva);
 
 	void ReadCatchClauses(Module *module, TryBlock *tryBlock, const module_file::CatchClauses &catchClauses);
 

--- a/ovum-vm/src/object/field.cpp
+++ b/ovum-vm/src/object/field.cpp
@@ -80,7 +80,7 @@ void Field::WriteFieldUnchecked(Value *instanceAndValue) const
 
 } // namespace ovum
 
-OVUM_API uint32_t Field_GetOffset(FieldHandle field)
+OVUM_API size_t Field_GetOffset(FieldHandle field)
 {
 	return field->offset;
 }

--- a/ovum-vm/src/object/field.h
+++ b/ovum-vm/src/object/field.h
@@ -11,7 +11,7 @@ class Field : public Member
 public:
 	union
 	{
-		int32_t offset;
+		size_t offset;
 		StaticRef *staticValue;
 	};
 
@@ -20,11 +20,15 @@ public:
 	{ }
 
 	int ReadField(Thread *const thread, Value *instance, Value *dest) const;
+
 	int ReadFieldFast(Thread *const thread, Value *instance, Value *dest) const;
+
 	void ReadFieldUnchecked(Value *instance, Value *dest) const;
 
 	int WriteField(Thread *const thread, Value *instanceAndValue) const;
+
 	int WriteFieldFast(Thread *const thread, Value *instanceAndValue) const;
+
 	void WriteFieldUnchecked(Value *instanceAndValue) const;
 };
 

--- a/ovum-vm/src/object/member.h
+++ b/ovum-vm/src/object/member.h
@@ -131,6 +131,7 @@ private:
 	Type *GetOriginatingType() const;
 
 	bool IsAccessibleProtected(const Type *instType, const Type *fromType) const;
+
 	bool IsAccessibleProtectedWithSharedType(const Type *instType, const Type *fromType) const;
 };
 

--- a/ovum-vm/src/object/method.cpp
+++ b/ovum-vm/src/object/method.cpp
@@ -88,7 +88,7 @@ inline bool Method::Accepts(ovlocals_t argCount) const
 	const Method *m = this;
 	do
 	{
-		for (int i = 0; i < m->overloadCount; i++)
+		for (size_t i = 0; i < m->overloadCount; i++)
 			if (m->overloads[i].Accepts(argCount))
 				return true;
 	} while (m = m->baseMethod);
@@ -100,7 +100,7 @@ MethodOverload *Method::ResolveOverload(ovlocals_t argCount) const
 	const Method *method = this;
 	do
 	{
-		for (int i = 0; i < method->overloadCount; i++)
+		for (size_t i = 0; i < method->overloadCount; i++)
 		{
 			MethodOverload *mo = method->overloads + i;
 			if (mo->Accepts(argCount))
@@ -113,7 +113,7 @@ MethodOverload *Method::ResolveOverload(ovlocals_t argCount) const
 void Method::SetDeclType(Type *type)
 {
 	this->declType = type;
-	for (int i = 0; i < overloadCount; i++)
+	for (size_t i = 0; i < overloadCount; i++)
 		this->overloads[i].declType = type;
 }
 
@@ -124,24 +124,24 @@ OVUM_API bool Method_IsConstructor(MethodHandle method)
 {
 	return method->IsCtor();
 }
-OVUM_API int32_t Method_GetOverloadCount(MethodHandle method)
+OVUM_API size_t Method_GetOverloadCount(MethodHandle method)
 {
 	return method->overloadCount;
 }
-OVUM_API OverloadHandle Method_GetOverload(MethodHandle method, int32_t index)
+OVUM_API OverloadHandle Method_GetOverload(MethodHandle method, size_t index)
 {
-	if (index < 0 || index >= method->overloadCount)
+	if (index >= method->overloadCount)
 		return nullptr;
 
 	return method->overloads + index;
 }
-OVUM_API int32_t Method_GetOverloads(MethodHandle method, int32_t destSize, OverloadHandle *dest)
+OVUM_API size_t Method_GetOverloads(MethodHandle method, size_t destSize, OverloadHandle *dest)
 {
-	int32_t count = method->overloadCount;
+	size_t count = method->overloadCount;
 	if (count > destSize)
 		count = destSize;
 
-	for (int32_t i = 0; i < count; i++)
+	for (size_t i = 0; i < count; i++)
 		dest[i] = method->overloads + i;
 
 	return count;
@@ -157,8 +157,6 @@ OVUM_API bool Method_Accepts(MethodHandle method, ovlocals_t argc)
 }
 OVUM_API OverloadHandle Method_FindOverload(MethodHandle method, ovlocals_t argc)
 {
-	if (argc < 0 || argc > UINT16_MAX)
-		return nullptr;
 	return method->ResolveOverload(argc);
 }
 
@@ -167,7 +165,7 @@ OVUM_API uint32_t Overload_GetFlags(OverloadHandle overload)
 {
 	return static_cast<uint32_t>(overload->flags & ovum::OverloadFlags::VISIBLE_MASK);
 }
-OVUM_API int32_t Overload_GetParamCount(OverloadHandle overload)
+OVUM_API ovlocals_t Overload_GetParamCount(OverloadHandle overload)
 {
 	return overload->paramCount;
 }
@@ -191,7 +189,7 @@ OVUM_API bool Overload_GetParameter(OverloadHandle overload, ovlocals_t index, P
 
 	return true;
 }
-OVUM_API int32_t Overload_GetAllParameters(OverloadHandle overload, ovlocals_t destSize, ParamInfo *dest)
+OVUM_API ovlocals_t Overload_GetAllParameters(OverloadHandle overload, ovlocals_t destSize, ParamInfo *dest)
 {
 	ovlocals_t count = overload->paramCount;
 	if (count > destSize)

--- a/ovum-vm/src/object/method.h
+++ b/ovum-vm/src/object/method.h
@@ -57,10 +57,10 @@ struct CatchBlock
 {
 	Type *caughtType;
 	uint32_t caughtTypeId;
-	uint32_t catchStart;
-	uint32_t catchEnd;
+	size_t catchStart;
+	size_t catchEnd;
 
-	inline bool Contains(uint32_t offset) const
+	inline bool Contains(size_t offset) const
 	{
 		return catchStart <= offset && offset < catchEnd;
 	}
@@ -68,16 +68,16 @@ struct CatchBlock
 
 struct CatchBlocks
 {
-	int32_t count;
+	size_t count;
 	CatchBlock *blocks;
 };
 
 struct FinallyBlock
 {
-	uint32_t finallyStart;
-	uint32_t finallyEnd;
+	size_t finallyStart;
+	size_t finallyEnd;
 
-	inline bool Contains(uint32_t offset) const
+	inline bool Contains(size_t offset) const
 	{
 		return finallyStart <= offset && offset < finallyEnd;
 	}
@@ -95,8 +95,8 @@ class TryBlock
 public:
 
 	TryKind kind;
-	uint32_t tryStart;
-	uint32_t tryEnd;
+	size_t tryStart;
+	size_t tryEnd;
 
 	union
 	{
@@ -104,11 +104,13 @@ public:
 		FinallyBlock finallyBlock;
 	};
 
-	inline TryBlock()
-		: kind((TryKind)0)
+	inline TryBlock() :
+		kind((TryKind)0)
 	{ }
-	inline TryBlock(TryKind kind, uint32_t tryStart, uint32_t tryEnd)
-		: kind(kind), tryStart(tryStart), tryEnd(tryEnd)
+	inline TryBlock(TryKind kind, size_t tryStart, size_t tryEnd) :
+		kind(kind),
+		tryStart(tryStart),
+		tryEnd(tryEnd)
 	{
 		if (kind == TryKind::CATCH)
 			catches.blocks = nullptr;
@@ -124,7 +126,7 @@ public:
 		}
 	}
 
-	inline bool Contains(uint32_t offset) const
+	inline bool Contains(size_t offset) const
 	{
 		return tryStart <= offset && offset < tryEnd;
 	}
@@ -151,7 +153,7 @@ public:
 	String **paramNames;
 	uint32_t refSignature;
 
-	int32_t tryBlockCount;
+	size_t tryBlockCount;
 	TryBlock *tryBlocks;
 
 	// The maximum number of stack slots the method uses. This value is
@@ -166,7 +168,7 @@ public:
 		struct
 		{
 			uint8_t *entry;
-			uint32_t length; // The length of the method body, in bytes.
+			size_t length; // The length of the method body, in bytes.
 		};
 		NativeMethod nativeEntry;
 	};
@@ -298,7 +300,7 @@ class Method : public Member
 {
 public:
 	// The number of overloads in the method.
-	int32_t overloadCount;
+	size_t overloadCount;
 	// The overloads of the method.
 	MethodOverload *overloads;
 	// If this method is not a global function and the base type declares

--- a/ovum-vm/src/object/standardtypeinfo.h
+++ b/ovum-vm/src/object/standardtypeinfo.h
@@ -55,13 +55,10 @@ struct StandardTypeInfo
 // must be exported by the native module declaring the type.
 class StandardTypeCollection
 {
-private:
-	StringHash<StandardTypeInfo> types;
-
 public:
 	OVUM_NOINLINE static Box<StandardTypeCollection> New(VM *vm);
 
-	inline int32_t GetCount() const
+	inline size_t GetCount() const
 	{
 		return types.GetCount();
 	}
@@ -71,12 +68,14 @@ public:
 		return types.Get(name, result);
 	}
 
-	inline bool GetByIndex(int32_t index, StandardTypeInfo &result) const
+	inline bool GetByIndex(size_t index, StandardTypeInfo &result) const
 	{
 		return types.GetByIndex(index, result);
 	}
 
 private:
+	StringHash<StandardTypeInfo> types;
+
 	StandardTypeCollection();
 
 	bool Init(VM *vm);

--- a/ovum-vm/src/object/type.cpp
+++ b/ovum-vm/src/object/type.cpp
@@ -13,7 +13,7 @@
 namespace ovum
 {
 
-Type::Type(Module *module, int32_t memberCount) :
+Type::Type(Module *module, size_t memberCount) :
 	members(memberCount),
 	typeToken(nullptr),
 	size(0),
@@ -43,7 +43,7 @@ void Type::InitOperators()
 		return;
 
 	OVUM_ASSERT(baseType->AreOpsInited());
-	for (int op = 0; op < OPERATOR_COUNT; op++)
+	for (size_t op = 0; op < OPERATOR_COUNT; op++)
 	{
 		if (!this->operators[op])
 			this->operators[op] = baseType->operators[op];
@@ -116,7 +116,7 @@ bool Type::InitStaticFields(Thread *const thread)
 	Value nullValue;
 	nullValue.type = nullptr;
 
-	for (int32_t i = 0; i < members.count; i++)
+	for (size_t i = 0; i < members.count; i++)
 	{
 		Member *m = members.entries[i].value;
 		if (m->IsField() &&
@@ -172,9 +172,12 @@ int Type::RunStaticCtor(Thread *const thread)
 			}
 
 			Value ignore;
-			r = thread->InvokeMethodOverload(mo, 0,
+			r = thread->InvokeMethodOverload(
+				mo,
+				0,
 				thread->currentFrame->evalStack + thread->currentFrame->stackCount,
-				&ignore);
+				&ignore
+			);
 			if (r != OVUM_SUCCESS)
 			{
 				flags &= ~TypeFlags::STATIC_CTOR_RUNNING;
@@ -194,7 +197,7 @@ int Type::AddNativeField(size_t offset, NativeFieldType fieldType)
 {
 	if (fieldCount == nativeFieldCapacity)
 	{
-		uint32_t newCap = nativeFieldCapacity ? 2 * nativeFieldCapacity : 4;
+		size_t newCap = nativeFieldCapacity ? 2 * nativeFieldCapacity : 4;
 		NativeField *newFields = reinterpret_cast<NativeField*>(realloc(nativeFields, sizeof(NativeField) * newCap));
 		if (newFields == nullptr)
 			return OVUM_ERROR_NO_MEMORY;
@@ -265,11 +268,11 @@ OVUM_API MemberHandle Type_FindMember(TypeHandle type, String *name, OverloadHan
 	return type->FindMember(name, fromMethod);
 }
 
-OVUM_API int32_t Type_GetMemberCount(TypeHandle type)
+OVUM_API size_t Type_GetMemberCount(TypeHandle type)
 {
 	return type->members.GetCount();
 }
-OVUM_API MemberHandle Type_GetMemberByIndex(TypeHandle type, const int32_t index)
+OVUM_API MemberHandle Type_GetMemberByIndex(TypeHandle type, size_t index)
 {
 	ovum::Member *result;
 	if (type->members.GetByIndex(index, result))
@@ -286,7 +289,7 @@ OVUM_API int Type_GetTypeToken(ThreadHandle thread, TypeHandle type, Value *resu
 	return type->GetTypeToken(thread, result);
 }
 
-OVUM_API uint32_t Type_GetFieldOffset(TypeHandle type)
+OVUM_API size_t Type_GetFieldOffset(TypeHandle type)
 {
 	return type->fieldsOffset;
 }

--- a/ovum-vm/src/object/type.h
+++ b/ovum-vm/src/object/type.h
@@ -68,17 +68,19 @@ public:
 		NativeFieldType type;
 	};
 
-	Type(Module *module, int32_t memberCount);
+	Type(Module *module, size_t memberCount);
+
 	~Type();
 
 	Member *GetMember(String *name) const;
+
 	Member *FindMember(String *name, MethodOverload *fromMethod) const;
 
 	// Flags associated with the type.
 	TypeFlags flags;
 
 	// The offset (in bytes) of the first field in instances of this type.
-	uint32_t fieldsOffset;
+	size_t fieldsOffset;
 	// The total size (in bytes) of instances of this type, not including
 	// the size consumed by the base type.
 	// Note: this is 0 for Object and String, the latter of which is variable-size.
@@ -86,7 +88,7 @@ public:
 	// The total number of instance fields in the type. If the flag CUSTOMPTR
 	// is set, this contains the number of native fields; otherwise, this is
 	// the number of Value fields.
-	int fieldCount;
+	size_t fieldCount;
 
 	// Members! These allow us to look up members by name.
 	StringHash<Member*> members;
@@ -115,7 +117,7 @@ public:
 	Finalizer finalizer;
 	// The number of native fields that can be defined before the array
 	// must be resized.
-	uint32_t nativeFieldCapacity;
+	size_t nativeFieldCapacity;
 	// Native fields defined on the type
 	NativeField *nativeFields;
 
@@ -127,7 +129,7 @@ public:
 	// The number of overloadable operators.
 	// If you change Operator and/or Opcode without changing this,
 	// you have no one to blame but yourself.
-	static const int OPERATOR_COUNT = 16;
+	static const size_t OPERATOR_COUNT = 16;
 	// Operator implementations. If an operator implementation is null,
 	// then the type does not implement that operator.
 	MethodOverload *operators[OPERATOR_COUNT];
@@ -224,7 +226,9 @@ public:
 	}
 
 	void InitOperators();
+
 	bool InitStaticFields(Thread *const thread);
+
 	int RunStaticCtor(Thread *const thread);
 
 	int AddNativeField(size_t offset, NativeFieldType fieldType);

--- a/ovum-vm/src/os/_template/console.h
+++ b/ovum-vm/src/os/_template/console.h
@@ -44,7 +44,7 @@ namespace os
 	// Returns:
 	//   True if the string was fully written; false if an error occurred.
 	//   There is no extended error information for this call.
-	bool ConsoleWrite(ConsoleInfo *console, const ovchar_t *str, int32_t length);
+	bool ConsoleWrite(ConsoleInfo *console, const ovchar_t *str, size_t length);
 
 	// Writes an Ovum string to the console, to stdout.
 	//   console:
@@ -71,7 +71,7 @@ namespace os
 	// Returns:
 	//   True if the string was fully written; false if an error occurred.
 	//   There is no extended error information for this call.
-	bool ConsoleWriteError(ConsoleInfo *console, const ovchar_t *str, int32_t length);
+	bool ConsoleWriteError(ConsoleInfo *console, const ovchar_t *str, size_t length);
 
 	// Writes an Ovum string to the console, to stderr.
 	//   console:

--- a/ovum-vm/src/os/windows.h
+++ b/ovum-vm/src/os/windows.h
@@ -22,4 +22,7 @@
 #undef FILE_SHARE_WRITE
 #undef FILE_SHARE_DELETE
 
+// The type ssize_t is POSIX-specific, but it's quite useful, so define it here.
+typedef SSIZE_T ssize_t;
+
 #include "windows/def.h"

--- a/ovum-vm/src/os/windows/console.h
+++ b/ovum-vm/src/os/windows/console.h
@@ -22,7 +22,7 @@ namespace os
 		UINT previousCodePage;
 	};
 
-	bool ConsoleWrite_(HANDLE handle, const ovchar_t *str, int32_t strLength);
+	bool ConsoleWrite_(HANDLE handle, const ovchar_t *str, size_t strLength);
 
 	// Initializes a ConsoleInfo with information about the current console.
 	//   console:
@@ -56,7 +56,7 @@ namespace os
 	// Returns:
 	//   True if the string was fully written; false if an error occurred.
 	//   There is no extended error information for this call.
-	inline bool ConsoleWrite(ConsoleInfo *console, const ovchar_t *str, int32_t length)
+	inline bool ConsoleWrite(ConsoleInfo *console, const ovchar_t *str, size_t length)
 	{
 		return ConsoleWrite_(console->stdOut, str, length);
 	}
@@ -84,7 +84,7 @@ namespace os
 	// Returns:
 	//   True if the string was fully written; false if an error occurred.
 	//   There is no extended error information for this call.
-	inline bool ConsoleWriteError(ConsoleInfo *console, const ovchar_t *str, int32_t length)
+	inline bool ConsoleWriteError(ConsoleInfo *console, const ovchar_t *str, size_t length)
 	{
 		return ConsoleWrite_(console->stdErr, str, length);
 	}

--- a/ovum-vm/src/os/windows/windows.cpp
+++ b/ovum-vm/src/os/windows/windows.cpp
@@ -87,10 +87,10 @@ namespace os
 		}
 	}
 
-	bool ConsoleWriteFile(HANDLE handle, const ovchar_t *str, int32_t length)
+	bool ConsoleWriteFile(HANDLE handle, const ovchar_t *str, size_t length)
 	{
 		// Assume the console can handle UTF-8
-		const int32_t BUFFER_SIZE = 2048;
+		const size_t BUFFER_SIZE = 2048;
 		char buffer[BUFFER_SIZE];
 		Utf8Encoder encoder(buffer, BUFFER_SIZE, str, length);
 
@@ -114,7 +114,7 @@ namespace os
 		return true;
 	}
 
-	bool ConsoleWrite_(HANDLE handle, const ovchar_t *str, int32_t length)
+	bool ConsoleWrite_(HANDLE handle, const ovchar_t *str, size_t length)
 	{
 		DWORD remaining = (DWORD)length;
 		do

--- a/ovum-vm/src/threading/sync.h
+++ b/ovum-vm/src/threading/sync.h
@@ -13,7 +13,7 @@ namespace ovum
 class CriticalSection
 {
 public:
-	inline CriticalSection(int spinCount)
+	inline explicit CriticalSection(int spinCount)
 	{
 		os::CriticalSectionInit(&cs, spinCount);
 	}
@@ -61,7 +61,7 @@ private:
 class Semaphore
 {
 public:
-	inline Semaphore(int value)
+	inline explicit Semaphore(int value)
 	{
 		os::SemaphoreInit(&semaphore, value);
 	}

--- a/ovum-vm/src/threading/tls.h
+++ b/ovum-vm/src/threading/tls.h
@@ -7,20 +7,16 @@
 
 namespace ovum
 {
+
 // Implements a thread-local storage entry. The thread-local storage slot
 // contains a pointer to T. The constructor for TlsEntry does not attempt
 // to allocate a TLS slot; that is done by the Alloc method.
 template<typename T>
 class TlsEntry
 {
-private:
-	bool inited;
-	os::TlsKey key;
-
-	OVUM_DISABLE_COPY_AND_ASSIGN(TlsEntry);
-
 public:
-	inline TlsEntry() : inited(false)
+	inline TlsEntry() :
+		inited(false)
 	{ }
 
 	// Determines whether the TLS key is valid, that is,
@@ -69,6 +65,12 @@ public:
 		if (IsValid())
 			os::TlsSet(&key, value);
 	}
+
+private:
+	bool inited;
+	os::TlsKey key;
+
+	OVUM_DISABLE_COPY_AND_ASSIGN(TlsEntry);
 };
 
 } // namespace ovum

--- a/ovum-vm/src/unicode/unicode.h
+++ b/ovum-vm/src/unicode/unicode.h
@@ -15,18 +15,19 @@ namespace unicode
 		int32_t lower;
 	};
 
-	inline CaseMap operator+(const CaseOffsets &map, const int32_t codepoint)
+	inline CaseMap operator+(const CaseOffsets &map, int32_t codepoint)
 	{
 		const CaseMap output = { map.upper + codepoint, map.lower + codepoint };
 		return output;
 	}
 
-	inline CaseMap operator+(const int32_t codepoint, const CaseOffsets &map)
+	inline CaseMap operator+(int32_t codepoint, const CaseOffsets &map)
 	{
 		return map + codepoint;
 	}
 
 	UnicodeCategory GetCategory(int32_t codepoint);
+
 	CaseMap GetCaseMap(int32_t codepoint);
 
 	namespace categories

--- a/ovum-vm/src/unicode/utf8encoder.cpp
+++ b/ovum-vm/src/unicode/utf8encoder.cpp
@@ -4,30 +4,33 @@
 namespace ovum
 {
 
-Utf8Encoder::Utf8Encoder(char *buffer, int32_t bufferLength) :
-	buffer(buffer), bufferEnd(buffer + bufferLength)
+Utf8Encoder::Utf8Encoder(char *buffer, size_t bufferLength) :
+	buffer(buffer),
+	bufferEnd(buffer + bufferLength)
 {
 	SetString(nullptr, 0);
 }
-Utf8Encoder::Utf8Encoder(char *buffer, int32_t bufferLength, String *str) :
-	buffer(buffer), bufferEnd(buffer + bufferLength)
+Utf8Encoder::Utf8Encoder(char *buffer, size_t bufferLength, String *str) :
+	buffer(buffer),
+	bufferEnd(buffer + bufferLength)
 {
 	SetString(str);
 }
-Utf8Encoder::Utf8Encoder(char *buffer, int32_t bufferLength, const ovchar_t *str, int32_t strLength) :
-	buffer(buffer), bufferEnd(buffer + bufferLength)
+Utf8Encoder::Utf8Encoder(char *buffer, size_t bufferLength, const ovchar_t *str, size_t strLength) :
+	buffer(buffer),
+	bufferEnd(buffer + bufferLength)
 {
 	SetString(str, strLength);
 }
 
-void Utf8Encoder::SetString(const ovchar_t *str, int32_t strLength)
+void Utf8Encoder::SetString(const ovchar_t *str, size_t strLength)
 {
 	this->str = str;
 	this->strLength = strLength;
 	this->unmatchedSurrogateLead = 0;
 }
 
-int32_t Utf8Encoder::GetNextBytes()
+size_t Utf8Encoder::GetNextBytes()
 {
 	// Current byte in the buffer
 	char *bufp = this->buffer;

--- a/ovum-vm/src/unicode/utf8encoder.h
+++ b/ovum-vm/src/unicode/utf8encoder.h
@@ -19,6 +19,33 @@ namespace ovum
 // than four bytes of space.
 class Utf8Encoder
 {
+public:
+	Utf8Encoder(char *buffer, size_t bufferLength);
+	Utf8Encoder(char *buffer, size_t bufferLength, String *str);
+	Utf8Encoder(char *buffer, size_t bufferLength, const ovchar_t *str, size_t strLength);
+
+	inline const char *GetBuffer()
+	{
+		return buffer;
+	}
+
+	inline size_t GetBufferLength()
+	{
+		return bufferEnd - buffer;
+	}
+
+	inline void SetString(String *str)
+	{
+		SetString(&str->firstChar, str->length);
+	}
+	void SetString(const ovchar_t *str, size_t strLength);
+
+	// Encodes the current string data into the buffer. This method will
+	// attempt to encode the entire string or fill up the buffer, whichever
+	// comes first. The value returned is the number of UTF-8 bytes written.
+	// When this method returns 0, the end of the string has been reached.
+	size_t GetNextBytes();
+
 private:
 	// The first byte of the destination buffer.
 	char *const buffer;
@@ -28,42 +55,14 @@ private:
 	// The string data. Note that these are current values; the pointer and
 	// the (remaining) length are updated by GetNextBytes().
 	const ovchar_t *str;
-	int32_t strLength;
+	size_t strLength;
 
 	// Currently pending surrogate lead. If a character other than a
 	// surrogate trail is encountered when this field is nonzero, the
 	// UTF-16 is invalid and we must output the replacement character.
 	ovchar_t unmatchedSurrogateLead;
 
-public:
-	Utf8Encoder(char *buffer, int32_t bufferLength);
-	Utf8Encoder(char *buffer, int32_t bufferLength, String *str);
-	Utf8Encoder(char *buffer, int32_t bufferLength, const ovchar_t *str, int32_t strLength);
-
-	inline const char *GetBuffer()
-	{
-		return buffer;
-	}
-
-	inline int32_t GetBufferLength()
-	{
-		return bufferEnd - buffer;
-	}
-
-	inline void SetString(String *str)
-	{
-		SetString(&str->firstChar, str->length);
-	}
-	void SetString(const ovchar_t *str, int32_t strLength);
-
-	// Encodes the current string data into the buffer. This method will
-	// attempt to encode the entire string or fill up the buffer, whichever
-	// comes first. The value returned is the number of UTF-8 bytes written.
-	// When this method returns 0, the end of the string has been reached.
-	int32_t GetNextBytes();
-
-private:
-	inline bool CanAppend(char *buffer, int32_t count) const
+	inline bool CanAppend(char *buffer, size_t count) const
 	{
 		return buffer + count <= bufferEnd;
 	}

--- a/ovum-vm/src/util/helpers.cpp
+++ b/ovum-vm/src/util/helpers.cpp
@@ -7,8 +7,8 @@
 
 namespace hash_helper
 {
-	const int32_t PrimeCount = 72;
-	const int32_t Primes[] = {
+	const size_t PrimeCount = 72;
+	const size_t Primes[] = {
 		3, 7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131, 163, 197,
 		239, 293, 353, 431, 521, 631, 761, 919, 1103, 1327, 1597, 1931,
 		2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143,
@@ -120,29 +120,29 @@ OVUM_API int StringFromValue(ThreadHandle thread, Value *v)
 
 // HASH HELPERS
 
-bool HashHelper_IsPrime(int32_t n)
+bool HashHelper_IsPrime(size_t n)
 {
 	if ((n & 1) == 0)
 		// 2 is the only even prime!
 		return n == 2;
 
-	int32_t max = (int32_t)sqrt((double)n);
-	for (int32_t div = 3; div <= max; div += 2)
+	size_t max = (size_t)sqrt((double)n);
+	for (size_t div = 3; div <= max; div += 2)
 		if ((n % div) == 0)
 			return false;
 
 	return true;
 }
 
-OVUM_API int32_t HashHelper_GetPrime(int32_t min)
+OVUM_API size_t HashHelper_GetPrime(size_t min)
 {
 	// Check the table first
-	for (int i = 0; i < hash_helper::PrimeCount; i++)
+	for (size_t i = 0; i < hash_helper::PrimeCount; i++)
 		if (hash_helper::Primes[i] >= min)
 			return hash_helper::Primes[i];
 
 	// Outside of the table; time to compute!
-	for (int32_t i = min | 1; i < INT32_MAX; i += 2)
+	for (size_t i = min | 1; i < SIZE_MAX; i += 2)
 		if (HashHelper_IsPrime(i))
 			return i;
 

--- a/ovum-vm/src/util/pathname.cpp
+++ b/ovum-vm/src/util/pathname.cpp
@@ -10,26 +10,34 @@ namespace ovum
 
 const PathName::noinit_t PathName::noinit = { };
 
-PathName::PathName(noinit_t)
-	: data(nullptr), length(0), capacity(0)
+PathName::PathName(noinit_t) :
+	data(nullptr),
+	length(0),
+	capacity(0)
 { }
 
-PathName::PathName(const pathchar_t *const path)
-	: data(nullptr), length(0), capacity(0)
+PathName::PathName(const pathchar_t *const path) :
+	data(nullptr),
+	length(0),
+	capacity(0)
 {
-	uint32_t pathLength = StringLength(path);
+	size_t pathLength = StringLength(path);
 	Init(pathLength);
 	this->length = pathLength;
 	CopyMemoryT(this->data, path, pathLength + 1); // +1 for \0
 }
-PathName::PathName(uint32_t capacity)
-	: data(nullptr), length(0), capacity(0)
+PathName::PathName(size_t capacity) :
+	data(nullptr),
+	length(0),
+	capacity(0)
 {
 	Init(capacity);
 	data[0] = ZERO;
 }
-PathName::PathName(String *path)
-	: data(nullptr), length(0), capacity(0)
+PathName::PathName(String *path) :
+	data(nullptr),
+	length(0),
+	capacity(0)
 {
 #if OVUM_WIDE_PATHCHAR
 	Init(path->length);
@@ -39,18 +47,22 @@ PathName::PathName(String *path)
 #error Not implemented
 #endif
 }
-PathName::PathName(const PathName &other)
-	: data(nullptr), length(0), capacity(0)
+PathName::PathName(const PathName &other) :
+	data(nullptr),
+	length(0),
+	capacity(0)
 {
 	Init(other.length);
 	this->length = other.length;
 	CopyMemoryT(this->data, other.data, other.length + 1); // +1 for \0
 }
 
-PathName::PathName(const pathchar_t *const path, std::nothrow_t)
-	: data(nullptr), length(0), capacity(0)
+PathName::PathName(const pathchar_t *const path, std::nothrow_t) :
+	data(nullptr),
+	length(0),
+	capacity(0)
 {
-	uint32_t pathLength = StringLength(path);
+	size_t pathLength = StringLength(path);
 	Init(pathLength, std::nothrow);
 	if (IsValid())
 	{
@@ -58,15 +70,19 @@ PathName::PathName(const pathchar_t *const path, std::nothrow_t)
 		CopyMemoryT(this->data, path, pathLength + 1); // +1 for \0
 	}
 }
-PathName::PathName(uint32_t capacity, std::nothrow_t)
-	: data(nullptr), length(0), capacity(0)
+PathName::PathName(size_t capacity, std::nothrow_t) :
+	data(nullptr),
+	length(0),
+	capacity(0)
 {
 	Init(capacity, std::nothrow);
 	if (IsValid())
 		data[0] = ZERO;
 }
-PathName::PathName(String *path, std::nothrow_t)
-	: data(nullptr), length(0), capacity(0)
+PathName::PathName(String *path, std::nothrow_t) :
+	data(nullptr),
+	length(0),
+	capacity(0)
 {
 #if OVUM_WIDE_PATHCHAR
 	Init(path->length, std::nothrow);
@@ -79,8 +95,10 @@ PathName::PathName(String *path, std::nothrow_t)
 #error Not implemented
 #endif
 }
-PathName::PathName(const PathName &other, std::nothrow_t)
-	: data(nullptr), length(0), capacity(0)
+PathName::PathName(const PathName &other, std::nothrow_t) :
+	data(nullptr),
+	length(0),
+	capacity(0)
 {
 	Init(other.length, std::nothrow);
 	if (IsValid())
@@ -104,25 +122,25 @@ String *PathName::ToManagedString(ThreadHandle thread) const
 #endif
 }
 
-void PathName::Init(uint32_t capacity)
+void PathName::Init(size_t capacity)
 {
 	this->data = new pathchar_t[capacity + 1]; // +1 for \0
 	this->capacity = capacity;
 }
-void PathName::Init(uint32_t capacity, std::nothrow_t)
+void PathName::Init(size_t capacity, std::nothrow_t)
 {
 	this->data = new(std::nothrow) pathchar_t[capacity + 1]; // +1 for \0
 	if (IsValid())
 		this->capacity = capacity;
 }
 
-bool PathName::EnsureMinCapacity(uint32_t minCapacity)
+bool PathName::EnsureMinCapacity(size_t minCapacity)
 {
 	using namespace std;
 
 	if (this->capacity < minCapacity)
 	{
-		uint32_t newCap = max(minCapacity, this->capacity * 2);
+		size_t newCap = max(minCapacity, this->capacity * 2);
 		unique_ptr<pathchar_t[]> newValues(new(std::nothrow) pathchar_t[newCap]);
 		if (newValues.get() == nullptr)
 			return false;
@@ -136,10 +154,10 @@ bool PathName::EnsureMinCapacity(uint32_t minCapacity)
 	return true;
 }
 
-uint32_t PathName::RemoveFileName()
+size_t PathName::RemoveFileName()
 {
-	uint32_t root = GetRootLength(length, data);
-	uint32_t i = length;
+	size_t root = GetRootLength(length, data);
+	size_t i = length;
 	while (i > root && !IsPathSep(data[--i]))
 		;
 	// i is now at the path separator, or at the last
@@ -149,7 +167,7 @@ uint32_t PathName::RemoveFileName()
 	return i;
 }
 
-uint32_t PathName::ClipTo(uint32_t index, uint32_t length)
+size_t PathName::ClipTo(size_t index, size_t length)
 {
 	if (index >= this->length || length == 0)
 	{
@@ -165,7 +183,7 @@ uint32_t PathName::ClipTo(uint32_t index, uint32_t length)
 		length = min(this->length - index, length);
 		// Copy one character at a time instead of using CopyMemoryT,
 		// to avoid potential problems with overlapping characters.
-		for (uint32_t i = 0; i < length; i++)
+		for (size_t i = 0; i < length; i++)
 			data[i] = data[index + i];
 		data[length] = ZERO;
 		this->length = length;
@@ -173,7 +191,7 @@ uint32_t PathName::ClipTo(uint32_t index, uint32_t length)
 	return this->length;
 }
 
-uint32_t PathName::AppendInner(uint32_t length, const pathchar_t *path)
+size_t PathName::AppendInner(size_t length, const pathchar_t *path)
 {
 	if (length > 0)
 	{
@@ -188,25 +206,25 @@ uint32_t PathName::AppendInner(uint32_t length, const pathchar_t *path)
 	return this->length;
 }
 
-uint32_t PathName::AppendOvchar(uint32_t length, const ovchar_t *path)
+size_t PathName::AppendOvchar(size_t length, const ovchar_t *path)
 {
 #if OVUM_WIDE_PATHCHAR
 	return AppendInner(length, reinterpret_cast<const pathchar_t*>(path));
 #else
 	char buffer[UTF8_BUFFER_SIZE];
-	Utf8Encoder enc(buffer, UTF8_BUFFER_SIZE, path, (int32_t)length);
+	Utf8Encoder enc(buffer, UTF8_BUFFER_SIZE, path, length);
 
-	int32_t byteCount;
+	size_t byteCount;
 	while ((byteCount = enc.GetNextBytes()) != 0)
 	{
-		AppendInner((uint32_t)byteCount, reinterpret_cast<pathchar_t*>(buffer));
+		AppendInner(byteCount, reinterpret_cast<pathchar_t*>(buffer));
 	}
 
 	return this->length;
 #endif
 }
 
-uint32_t PathName::JoinInner(uint32_t length, const pathchar_t *path)
+size_t PathName::JoinInner(size_t length, const pathchar_t *path)
 {
 	if (IsRooted(length, path))
 	{
@@ -230,30 +248,30 @@ uint32_t PathName::JoinInner(uint32_t length, const pathchar_t *path)
 	return this->length;
 }
 
-uint32_t PathName::JoinOvchar(uint32_t length, const ovchar_t *path)
+size_t PathName::JoinOvchar(size_t length, const ovchar_t *path)
 {
 #if OVUM_WIDE_PATHCHAR
 	return JoinInner(length, reinterpret_cast<const pathchar_t*>(path));
 #else
 	char buffer[UTF8_BUFFER_SIZE];
-	Utf8Encoder enc(buffer, UTF8_BUFFER_SIZE, path, (int32_t)length);
+	Utf8Encoder enc(buffer, UTF8_BUFFER_SIZE, path, length);
 
-	int32_t byteCount;
+	size_t byteCount;
 	if ((byteCount = enc.GetNextBytes()) != 0)
 	{
 		// The first time we have to call JoinInner()
-		JoinInner((uint32_t)byteCount, reinterpret_cast<pathchar_t*>(buffer));
+		JoinInner(byteCount, reinterpret_cast<pathchar_t*>(buffer));
 
 		// And each following call must be to AppendInner()
 		while ((byteCount = enc.GetNextBytes()) != 0)
 		{
-			AppendInner((uint32_t)byteCount, reinterpret_cast<pathchar_t*>(buffer));
+			AppendInner(byteCount, reinterpret_cast<pathchar_t*>(buffer));
 		}
 	}
 #endif
 }
 
-void PathName::ReplaceWithInner(uint32_t length, const pathchar_t *path)
+void PathName::ReplaceWithInner(size_t length, const pathchar_t *path)
 {
 	if (!EnsureMinCapacity(length))
 		throw std::bad_alloc();
@@ -263,31 +281,31 @@ void PathName::ReplaceWithInner(uint32_t length, const pathchar_t *path)
 	this->data[length] = ZERO;
 }
 
-void PathName::ReplaceWithOvchar(uint32_t length, const ovchar_t *path)
+void PathName::ReplaceWithOvchar(size_t length, const ovchar_t *path)
 {
 #if OVUM_WIDE_PATHCHAR
 	ReplaceWithInner(length, reinterpret_cast<const pathchar_t*>(path));
 #else
 	// Re-encode the path to UTF-8
 	char buffer[UTF8_BUFFER_SIZE];
-	Utf8Encoder enc(buffer, UTF8_BUFFER_SIZE, path, (int32_t)length);
+	Utf8Encoder enc(buffer, UTF8_BUFFER_SIZE, path, length);
 
-	int32_t byteCount;
+	size_t byteCount;
 	if ((byteCount = enc.GetNextBytes()) != 0)
 	{
 		// The first time we have to call ReplaceWithInner()
-		ReplaceWithInner((uint32_t)byteCount, reinterpret_cast<pathchar_t*>(buffer));
+		ReplaceWithInner(byteCount, reinterpret_cast<pathchar_t*>(buffer));
 
 		// And each following call must be to AppendInner()
 		while ((byteCount = enc.GetNextBytes()) != 0)
 		{
-			AppendInner((uint32_t)byteCount, reinterpret_cast<pathchar_t*>(buffer));
+			AppendInner(byteCount, reinterpret_cast<pathchar_t*>(buffer));
 		}
 	}
 #endif
 }
 
-bool PathName::IsRooted(uint32_t length, const pathchar_t *path)
+bool PathName::IsRooted(size_t length, const pathchar_t *path)
 {
 	// Starts with path separator, e.g. /hello/nope
 	if (length >= 1 && IsPathSep(path[0]))
@@ -302,9 +320,9 @@ bool PathName::IsRooted(uint32_t length, const pathchar_t *path)
 	return false;
 }
 
-uint32_t PathName::GetRootLength(uint32_t length, const pathchar_t *path)
+size_t PathName::GetRootLength(size_t length, const pathchar_t *path)
 {
-	uint32_t index = 0;
+	size_t index = 0;
 
 	if (length >= 1 && IsPathSep(path[0]))
 	{
@@ -324,12 +342,12 @@ uint32_t PathName::GetRootLength(uint32_t length, const pathchar_t *path)
 	return index;
 }
 
-uint32_t PathName::StringLength(const pathchar_t *const str)
+size_t PathName::StringLength(const pathchar_t *const str)
 {
 #if OVUM_WIDE_PATHCHAR
-	return (uint32_t)wcslen(str);
+	return wcslen(str);
 #else
-	return (uint32_t)strlen(str);
+	return strlen(str);
 #endif
 }
 

--- a/ovum-vm/src/util/pathname.h
+++ b/ovum-vm/src/util/pathname.h
@@ -20,26 +20,26 @@ private:
 	// Size of the buffer used when re-encoding a path as UTF-8.
 	// Paths are extremely unlikely to be longer than this; there
 	// is simply no need for a larger buffer.
-	static const int32_t UTF8_BUFFER_SIZE = 128;
+	static const size_t UTF8_BUFFER_SIZE = 128;
 
 	// Pointer to the first character in the string
 	pathchar_t *data;
 	// Number of characters actually used
-	uint32_t length;
+	size_t length;
 	// Total size of character array
-	uint32_t capacity;
+	size_t capacity;
 
 	// No-init constructor; just sets all fields to their defaults
 	PathName(noinit_t);
 
 public:
 	explicit PathName(const pathchar_t *const path);
-	explicit PathName(uint32_t capacity);
+	explicit PathName(size_t capacity);
 	explicit PathName(String *path);
 	PathName(const PathName &other);
 
 	PathName(const pathchar_t *const path, std::nothrow_t);
-	PathName(uint32_t capacity, std::nothrow_t);
+	PathName(size_t capacity, std::nothrow_t);
 	PathName(String *path, std::nothrow_t);
 	PathName(const PathName &other, std::nothrow_t);
 
@@ -50,12 +50,12 @@ public:
 		return data != nullptr;
 	}
 
-	inline uint32_t GetLength() const
+	inline size_t GetLength() const
 	{
 		return length;
 	}
 
-	inline uint32_t GetCapacity() const
+	inline size_t GetCapacity() const
 	{
 		return capacity;
 	}
@@ -79,24 +79,24 @@ public:
 
 	// Appends the characters of another path to this instance as-is.
 	// Returns: The length of the path after appending.
-	inline uint32_t Append(const PathName &other)
+	inline size_t Append(const PathName &other)
 	{
 		return AppendInner(other.length, other.data);
 	}
-	inline uint32_t Append(const pathchar_t *path)
+	inline size_t Append(const pathchar_t *path)
 	{
 		return AppendInner(StringLength(path), path);
 	}
-	inline uint32_t Append(String *path)
+	inline size_t Append(String *path)
 	{
-		return AppendOvchar((uint32_t)path->length, &path->firstChar);
+		return AppendOvchar(path->length, &path->firstChar);
 	}
-	inline uint32_t Append(uint32_t length, const pathchar_t *path)
+	inline size_t Append(size_t length, const pathchar_t *path)
 	{
 		return AppendInner(length, path);
 	}
 #if !OVUM_WIDE_PATHCHAR
-	inline uint32_t Append(uint32_t length, const ovchar_t *path)
+	inline size_t Append(size_t length, const ovchar_t *path)
 	{
 		return AppendOvchar(length, path);
 	}
@@ -109,30 +109,30 @@ public:
 	//     this path, separated by a PATH_SEP if this path does
 	//     not end in one.
 	// Returns: The length of the path after joining.
-	inline uint32_t Join(const PathName &other)
+	inline size_t Join(const PathName &other)
 	{
 		return JoinInner(other.length, other.data);
 	}
-	inline uint32_t Join(const pathchar_t *path)
+	inline size_t Join(const pathchar_t *path)
 	{
 		return JoinInner(StringLength(path), path);
 	}
-	inline uint32_t Join(String *path)
+	inline size_t Join(String *path)
 	{
-		return JoinOvchar((uint32_t)path->length, &path->firstChar);
+		return JoinOvchar(path->length, &path->firstChar);
 	}
-	inline uint32_t Join(uint32_t length, const pathchar_t *path)
+	inline size_t Join(size_t length, const pathchar_t *path)
 	{
 		return JoinInner(length, path);
 	}
 #if !OVUM_WIDE_PATHCHAR
-	inline uint32_t Join(uint32_t length, const ovchar_t *path)
+	inline size_t Join(size_t length, const ovchar_t *path)
 	{
 		return JoinOvchar(length, path);
 	}
 #endif
 
-	uint32_t RemoveFileName();
+	size_t RemoveFileName();
 
 	inline void Clear()
 	{
@@ -153,15 +153,15 @@ public:
 	inline void ReplaceWith(String *path)
 	{
 		Clear();
-		ReplaceWithOvchar((uint32_t)path->length, &path->firstChar);
+		ReplaceWithOvchar(path->length, &path->firstChar);
 	}
-	inline void ReplaceWith(uint32_t length, const pathchar_t *path)
+	inline void ReplaceWith(size_t length, const pathchar_t *path)
 	{
 		Clear();
 		ReplaceWithInner(length, path);
 	}
 #if !OVUM_WIDE_PATHCHAR
-	inline void ReplaceWith(uint32_t length, const ovchar_t *path)
+	inline void ReplaceWith(size_t length, const ovchar_t *path)
 	{
 		Clear();
 		ReplaceWithOvchar(length, path);
@@ -171,38 +171,38 @@ public:
 	// Clips the path name to the specified substring, removing
 	// characters that are outside that range.
 	// Returns: The length of the string after clipping.
-	uint32_t ClipTo(uint32_t index, uint32_t length);
+	size_t ClipTo(size_t index, size_t length);
 
 	String *ToManagedString(ThreadHandle thread) const;
 
 private:
-	void Init(uint32_t capacity);
-	void Init(uint32_t capacity, std::nothrow_t);
+	void Init(size_t capacity);
+	void Init(size_t capacity, std::nothrow_t);
 
-	bool EnsureMinCapacity(uint32_t minCapacity);
+	bool EnsureMinCapacity(size_t minCapacity);
 
-	void ReplaceWithInner(uint32_t length, const pathchar_t *path);
+	void ReplaceWithInner(size_t length, const pathchar_t *path);
 
-	void ReplaceWithOvchar(uint32_t length, const ovchar_t *path);
+	void ReplaceWithOvchar(size_t length, const ovchar_t *path);
 
-	uint32_t AppendInner(uint32_t length, const pathchar_t *path);
+	size_t AppendInner(size_t length, const pathchar_t *path);
 
-	uint32_t AppendOvchar(uint32_t length, const ovchar_t *path);
+	size_t AppendOvchar(size_t length, const ovchar_t *path);
 
-	uint32_t JoinInner(uint32_t length, const pathchar_t *path);
+	size_t JoinInner(size_t length, const pathchar_t *path);
 
-	uint32_t JoinOvchar(uint32_t length, const ovchar_t *path);
+	size_t JoinOvchar(size_t length, const ovchar_t *path);
 
 	static inline bool IsPathSep(pathchar_t ch)
 	{
 		return ch == OVUM_PATH_SEPC || ch == OVUM_PATH_SEPC_ALT;
 	}
 
-	static bool IsRooted(uint32_t length, const pathchar_t *path);
+	static bool IsRooted(size_t length, const pathchar_t *path);
 
-	static uint32_t GetRootLength(uint32_t length, const pathchar_t *path);
+	static size_t GetRootLength(size_t length, const pathchar_t *path);
 
-	static uint32_t StringLength(const pathchar_t *const str);
+	static size_t StringLength(const pathchar_t *const str);
 };
 
 } // namespace ovum

--- a/ovum-vm/src/util/stringbuffer.h
+++ b/ovum-vm/src/util/stringbuffer.h
@@ -7,37 +7,41 @@ namespace ovum
 
 class StringBuffer
 {
-private:
-	int32_t capacity;
-	int32_t length;
-	ovchar_t *data;
-
 public:
-	StringBuffer(const int32_t capacity = StringBuffer::DefaultCapacity);
+	explicit StringBuffer(size_t capacity = StringBuffer::DefaultCapacity);
 	~StringBuffer();
 
-	inline int32_t GetLength()   { return this->length; }
-	inline int32_t GetCapacity() { return this->capacity; }
-	int32_t SetCapacity(const int32_t newCapacity);
+	inline size_t GetLength()
+	{
+		return this->length;
+	}
 
-	void Append(const ovchar_t ch);
-	void Append(const int32_t count, const ovchar_t ch);
-	void Append(const int32_t length, const ovchar_t data[]);
+	inline size_t GetCapacity()
+	{
+		return this->capacity;
+	}
+
+	size_t SetCapacity(size_t newCapacity);
+
+	void Append(ovchar_t ch);
+	void Append(size_t count, const ovchar_t ch);
+	void Append(size_t length, const ovchar_t data[]);
 	void Append(String *str);
 
-	void Append(const int32_t length, const char data[]);
+	void Append(size_t length, const char data[]);
 #if OVUM_WCHAR_SIZE != 2
-	void Append(const int32_t length, const wchar_t data[]);
+	void Append(size_t length, const wchar_t data[]);
 #endif
 
 	// Clears the buffer's contents without changing the capacity.
 	void Clear();
 
-	inline bool StartsWith(const ovchar_t ch)
+	inline bool StartsWith(ovchar_t ch)
 	{
 		return this->length > 0 && this->data[0] == ch;
 	}
-	inline bool EndsWith(const ovchar_t ch)
+
+	inline bool EndsWith(ovchar_t ch)
 	{
 		return this->length > 0 && this->data[this->length - 1] == ch;
 	}
@@ -46,10 +50,14 @@ public:
 
 	// If buf is null, returns only the size of the resulting string,
 	// including the terminating \0.
-	int ToWString(wchar_t *buf);
+	size_t ToWString(wchar_t *buf);
 
 private:
-	void EnsureMinCapacity(int32_t newAmount);
+	size_t capacity;
+	size_t length;
+	ovchar_t *data;
+
+	void EnsureMinCapacity(size_t newAmount);
 
 	static const size_t DefaultCapacity = 128;
 };

--- a/ovum-vm/src/util/stringformatters.cpp
+++ b/ovum-vm/src/util/stringformatters.cpp
@@ -4,7 +4,7 @@
 namespace ovum
 {
 
-int32_t IntFormatter::ToDec(int64_t number, StringBuffer &dest, int32_t minLength)
+size_t IntFormatter::ToDec(int64_t number, StringBuffer &dest, size_t minLength)
 {
 	bool isNeg = number < 0;
 	if (isNeg)
@@ -14,11 +14,11 @@ int32_t IntFormatter::ToDec(int64_t number, StringBuffer &dest, int32_t minLengt
 
 	ovchar_t buffer[BUFFER_SIZE];
 	ovchar_t *bufferEnd = buffer + BUFFER_SIZE;
-	int32_t numberLength = BuildDecString((uint64_t)number, bufferEnd);
+	size_t numberLength = BuildDecString((uint64_t)number, bufferEnd);
 	// Move the pointer to the first character
 	bufferEnd -= numberLength;
 
-	int32_t length = numberLength;
+	size_t length = numberLength;
 	if (isNeg)
 	{
 		dest.Append(MINUS);
@@ -36,15 +36,15 @@ int32_t IntFormatter::ToDec(int64_t number, StringBuffer &dest, int32_t minLengt
 	return length;
 }
 
-int32_t IntFormatter::ToDec(uint64_t number, StringBuffer &dest, int32_t minLength)
+size_t IntFormatter::ToDec(uint64_t number, StringBuffer &dest, size_t minLength)
 {
 	ovchar_t buffer[BUFFER_SIZE];
 	ovchar_t *bufferEnd = buffer + BUFFER_SIZE;
-	int32_t numberLength = BuildDecString(number, bufferEnd);
+	size_t numberLength = BuildDecString(number, bufferEnd);
 	// Move the pointer to the first character
 	bufferEnd -= numberLength;
 
-	int32_t length = numberLength;
+	size_t length = numberLength;
 
 	if (minLength >= length)
 	{
@@ -57,7 +57,7 @@ int32_t IntFormatter::ToDec(uint64_t number, StringBuffer &dest, int32_t minLeng
 	return length;
 }
 
-int32_t IntFormatter::ToDec(int64_t number, ovchar_t *dest, int32_t destSize)
+size_t IntFormatter::ToDec(int64_t number, ovchar_t *dest, size_t destSize)
 {
 	bool isNeg = number < 0;
 	if (isNeg)
@@ -67,11 +67,11 @@ int32_t IntFormatter::ToDec(int64_t number, ovchar_t *dest, int32_t destSize)
 
 	ovchar_t buffer[BUFFER_SIZE];
 	ovchar_t *bufferEnd = buffer + BUFFER_SIZE;
-	int32_t numberLength = BuildDecString((uint64_t)number, bufferEnd);
+	size_t numberLength = BuildDecString((uint64_t)number, bufferEnd);
 	// Move the pointer to the first character
 	bufferEnd -= numberLength;
 
-	int32_t length = numberLength + isNeg;
+	size_t length = numberLength + isNeg;
 	if (destSize < length)
 		// Destination buffer too small. Don't write anything to it; just
 		// return the required length.
@@ -85,11 +85,11 @@ int32_t IntFormatter::ToDec(int64_t number, ovchar_t *dest, int32_t destSize)
 	return length;
 }
 
-int32_t IntFormatter::ToDec(uint64_t number, ovchar_t *dest, int32_t destSize)
+size_t IntFormatter::ToDec(uint64_t number, ovchar_t *dest, size_t destSize)
 {
 	ovchar_t buffer[BUFFER_SIZE];
 	ovchar_t *bufferEnd = buffer + BUFFER_SIZE;
-	int32_t length = BuildDecString((uint64_t)number, bufferEnd);
+	size_t length = BuildDecString((uint64_t)number, bufferEnd);
 	// Move the pointer to the first character
 	bufferEnd -= length;
 
@@ -103,15 +103,15 @@ int32_t IntFormatter::ToDec(uint64_t number, ovchar_t *dest, int32_t destSize)
 	return length;
 }
 
-int32_t IntFormatter::ToHex(uint64_t number, StringBuffer &dest, bool upper, int32_t minLength)
+size_t IntFormatter::ToHex(uint64_t number, StringBuffer &dest, bool upper, size_t minLength)
 {
 	ovchar_t buffer[BUFFER_SIZE];
 	ovchar_t *bufferEnd = buffer + BUFFER_SIZE;
-	int32_t numberLength = BuildHexString(number, bufferEnd, upper);
+	size_t numberLength = BuildHexString(number, bufferEnd, upper);
 	// Move the pointer to the first character
 	bufferEnd -= numberLength;
 
-	int32_t length = numberLength;
+	size_t length = numberLength;
 
 	if (minLength > length)
 	{
@@ -124,11 +124,11 @@ int32_t IntFormatter::ToHex(uint64_t number, StringBuffer &dest, bool upper, int
 	return length;
 }
 
-int32_t IntFormatter::ToHex(uint64_t number, ovchar_t *dest, int32_t destSize, bool upper)
+size_t IntFormatter::ToHex(uint64_t number, ovchar_t *dest, size_t destSize, bool upper)
 {
 	ovchar_t buffer[BUFFER_SIZE];
 	ovchar_t *bufferEnd = buffer + BUFFER_SIZE;
-	int32_t length = BuildHexString(number, bufferEnd, upper);
+	size_t length = BuildHexString(number, bufferEnd, upper);
 	// Move the pointer to the first character
 	bufferEnd -= length;
 
@@ -142,7 +142,7 @@ int32_t IntFormatter::ToHex(uint64_t number, ovchar_t *dest, int32_t destSize, b
 	return length;
 }
 
-int32_t IntFormatter::BuildDecString(uint64_t number, ovchar_t *destEnd)
+size_t IntFormatter::BuildDecString(uint64_t number, ovchar_t *destEnd)
 {
 	ovchar_t *destp = destEnd;
 	do
@@ -155,7 +155,7 @@ int32_t IntFormatter::BuildDecString(uint64_t number, ovchar_t *destEnd)
 	return destEnd - destp;
 }
 
-int32_t IntFormatter::BuildHexString(uint64_t number, ovchar_t *destEnd, bool upper)
+size_t IntFormatter::BuildHexString(uint64_t number, ovchar_t *destEnd, bool upper)
 {
 	ovchar_t hexBase = upper ? HEX_UPPER_BASE : HEX_LOWER_BASE;
 

--- a/ovum-vm/src/util/stringformatters.h
+++ b/ovum-vm/src/util/stringformatters.h
@@ -11,47 +11,47 @@ namespace ovum
 class IntFormatter
 {
 public:
-	static inline int32_t ToDec(int32_t number, StringBuffer &dest, int32_t minLength = 0)
+	static inline size_t ToDec(int32_t number, StringBuffer &dest, size_t minLength = 0)
 	{
 		return ToDec((int64_t)number, dest, minLength);
 	}
 
-	static inline int32_t ToDec(uint32_t number, StringBuffer &dest, int32_t minLength = 0)
+	static inline size_t ToDec(uint32_t number, StringBuffer &dest, size_t minLength = 0)
 	{
 		return ToDec((uint64_t)number, dest, minLength);
 	}
 
-	static int32_t ToDec(int64_t number, StringBuffer &dest, int32_t minLength = 0);
+	static size_t ToDec(int64_t number, StringBuffer &dest, size_t minLength = 0);
 
-	static int32_t ToDec(uint64_t number, StringBuffer &dest, int32_t minLength = 0);
+	static size_t ToDec(uint64_t number, StringBuffer &dest, size_t minLength = 0);
 
-	static inline int32_t ToDec(int32_t number, ovchar_t *dest, int32_t destSize)
+	static inline size_t ToDec(int32_t number, ovchar_t *dest, size_t destSize)
 	{
 		return ToDec((int64_t)number, dest, destSize);
 	}
 
-	static inline int32_t ToDec(uint32_t number, ovchar_t *dest, int32_t destSize)
+	static inline size_t ToDec(uint32_t number, ovchar_t *dest, size_t destSize)
 	{
 		return ToDec((uint64_t)number, dest, destSize);
 	}
 
-	static int32_t ToDec(int64_t number, ovchar_t *dest, int32_t destSize);
+	static size_t ToDec(int64_t number, ovchar_t *dest, size_t destSize);
 
-	static int32_t ToDec(uint64_t number, ovchar_t *dest, int32_t destSize);
+	static size_t ToDec(uint64_t number, ovchar_t *dest, size_t destSize);
 
-	static inline int32_t ToHex(uint32_t number, StringBuffer &dest, bool upper, int32_t minLength = 0)
+	static inline size_t ToHex(uint32_t number, StringBuffer &dest, bool upper, size_t minLength = 0)
 	{
 		return ToHex((uint64_t)number, dest, upper, minLength);
 	}
 
-	static inline int32_t ToHex(uint32_t number, ovchar_t *dest, int32_t destSize, bool upper)
+	static inline size_t ToHex(uint32_t number, ovchar_t *dest, size_t destSize, bool upper)
 	{
 		return ToHex((uint64_t)number, dest, destSize, upper);
 	}
 
-	static int32_t ToHex(uint64_t number, StringBuffer &dest, bool upper, int32_t minLength = 0);
+	static size_t ToHex(uint64_t number, StringBuffer &dest, bool upper, size_t minLength = 0);
 
-	static int32_t ToHex(uint64_t number, ovchar_t *dest, int32_t destSize, bool upper);
+	static size_t ToHex(uint64_t number, ovchar_t *dest, size_t destSize, bool upper);
 
 private:
 	// These functions will never be called with anything larger than 64 bits.
@@ -59,7 +59,7 @@ private:
 	// 20 characters. Hence, a 32-char buffer will do just fine - that is,
 	// unless the minLength specifies something larger. In that case, we will
 	// have to use a heap buffer.
-	static const int32_t BUFFER_SIZE = 32;
+	static const size_t BUFFER_SIZE = 32;
 
 	static const ovchar_t ZERO = (ovchar_t)'0';
 	static const ovchar_t MINUS = (ovchar_t)'-';
@@ -67,9 +67,9 @@ private:
 	static const ovchar_t HEX_LOWER_BASE = (ovchar_t)'a';
 	static const ovchar_t HEX_UPPER_BASE = (ovchar_t)'A';
 
-	static int32_t BuildDecString(uint64_t number, ovchar_t *destEnd);
+	static size_t BuildDecString(uint64_t number, ovchar_t *destEnd);
 
-	static int32_t BuildHexString(uint64_t number, ovchar_t *destEnd, bool upper);
+	static size_t BuildHexString(uint64_t number, ovchar_t *destEnd, bool upper);
 };
 
 } // namespace ovum


### PR DESCRIPTION
Ovum has been highly inconsistent with its use of integral types, particularly `size_t`. For things that hold a count of things, Ovum has used a wildly varying mixture of `int32_t`, `uint32_t`, `int`, `unsigned int`, `uint16_t` (mostly in the past), and only occasionally `size_t`.

This commit attempts to remedy the problem.

First and foremost: Fields and variables that contain a count of things are now of type `size_t`. Likewise all methods that return values that represent counts. This includes internal things as well as the external API, Ovum as well as aves. Needless to say, this is a massive change. Some algorithms, such as looking up entries in hash tables, had to be modified.

Secondly: In some cases it is actually necessary to return negative numbers, for example to indicate error conditions. In these cases we use `ssize_t` instead. This type is actually POSIX-specific, but the Windows
header typedefs it to `SSIZE_T`, which serves the same purpose in Win32-land. The `ssize_t` type is used sparingly, and never in any public API functions; only internally in Ovum and aves.

Thirdly: While Ovum (now) uses `size_t`, which is unsigned, Osprey-facing APIs in aves prefer to return `aves.Int`-values, which are signed. On 32-bit every `size_t` fits inside `int64_t`; on 64-bit, especially large values of `size_t` do not fit inside `int64_t`. For this reason, the Ovum headers introduce the constant `OVUM_ISIZE_MAX`, which is used as the actual maximum capacity of lists, hashes, sets, arrays, buffers and other collection types that may arise. On 32-bit, it's `SIZE_MAX`; on 64-bit, it's `INT64_MAX`. The latter (9223 petabytes) should be enough for any reasonable uses of Ovum, and quite a lot of unreasonable uses too.

*Unfortunately,* C++ is entirely too fond of converting implicitly between all sorts of numeric types, whether the conversion is lossy or not, in various arithmetic operations, sometimes including comparisons. As a result, it is quite likely (in fact, virtually guaranteed) that I have missed several incorrect uses of integral types. These will be fixed as they are discovered.

Lastly, a variety of other fixes - chiefly formatting and memory management techniques (i.e. changing to `ovum::Box` in places) - have managed to sneak into this commit. Oh well.